### PR TITLE
Migrate PDF reader to EmbedPDF with annotation migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This project is made possible by the following open-source projects.
 - citation-js
 - Cytoscape
 - golden-layout
+- EmbedPDF
 - pdf.js
 - konva
 - vditor

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -90,6 +90,7 @@ yarn test:component:ci # 前端Vue Component测试
 - citation-js
 - cytoscape
 - golden-layout
+- EmbedPDF
 - pdf.js
 - konva
 - vditor

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@citation-js/plugin-csl": "^0.7.2",
     "@citation-js/plugin-isbn": "^0.4.0",
+    "@embedpdf/vue-pdf-viewer": "^2.6.1",
     "@excalidraw/excalidraw": "^0.15.2",
     "@quasar/extras": "^1.16.4",
     "@tauri-apps/api": "^1.5.3",

--- a/src/backend/pdfreader/embedAnnotationMigration.ts
+++ b/src/backend/pdfreader/embedAnnotationMigration.ts
@@ -1,0 +1,452 @@
+import type { AnnotationData, Rect } from "../database";
+import { AnnotationType, db, sqldb } from "../database";
+import type {
+  PdfAnnotationObject,
+  PdfDocumentObject,
+  PdfInkListObject,
+  Rect as PdfRect,
+  Size,
+} from "@embedpdf/models";
+import {
+  PdfAnnotationBorderStyle,
+  PdfAnnotationIcon,
+  PdfAnnotationSubtype,
+} from "@embedpdf/models";
+
+export const LEGACY_ANNOTATION_SOURCE = "sophosia-legacy-migration";
+
+const MARKUP_TYPES = new Set([
+  AnnotationType.HIGHLIGHT,
+  AnnotationType.UNDERLINE,
+  AnnotationType.STRIKEOUT,
+]);
+
+function parseLegacyRects(rects: AnnotationData["rects"] | string | undefined): Rect[] {
+  if (!rects) return [];
+  if (Array.isArray(rects)) return rects;
+  try {
+    return JSON.parse(rects) as Rect[];
+  } catch {
+    return [];
+  }
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeColor(color?: string) {
+  if (!color) return "#ffff00";
+  return color;
+}
+
+function pageSizeFor(document: PdfDocumentObject, pageIndex: number): Size | null {
+  const page = document.pages[pageIndex];
+  return page?.size || null;
+}
+
+function legacyRectPercentToPdfRect(rect: Rect, pageSize: Size): PdfRect {
+  return {
+    origin: {
+      x: clamp((toNumber(rect.left) / 100) * pageSize.width, 0, pageSize.width),
+      y: clamp((toNumber(rect.top) / 100) * pageSize.height, 0, pageSize.height),
+    },
+    size: {
+      width: clamp(
+        (toNumber(rect.width) / 100) * pageSize.width,
+        0,
+        pageSize.width
+      ),
+      height: clamp(
+        (toNumber(rect.height) / 100) * pageSize.height,
+        0,
+        pageSize.height
+      ),
+    },
+  };
+}
+
+function pdfRectToLegacyPercentRect(rect: PdfRect, pageSize: Size): Rect {
+  return {
+    left: (rect.origin.x / pageSize.width) * 100,
+    top: (rect.origin.y / pageSize.height) * 100,
+    width: (rect.size.width / pageSize.width) * 100,
+    height: (rect.size.height / pageSize.height) * 100,
+  };
+}
+
+function unionRects(rects: PdfRect[]): PdfRect | null {
+  if (!rects.length) return null;
+  let minX = rects[0].origin.x;
+  let minY = rects[0].origin.y;
+  let maxX = rects[0].origin.x + rects[0].size.width;
+  let maxY = rects[0].origin.y + rects[0].size.height;
+  for (const rect of rects.slice(1)) {
+    minX = Math.min(minX, rect.origin.x);
+    minY = Math.min(minY, rect.origin.y);
+    maxX = Math.max(maxX, rect.origin.x + rect.size.width);
+    maxY = Math.max(maxY, rect.origin.y + rect.size.height);
+  }
+  return {
+    origin: { x: minX, y: minY },
+    size: { width: maxX - minX, height: maxY - minY },
+  };
+}
+
+function defaultCommentRect(pageSize: Size, rect?: Rect): PdfRect {
+  const width = Math.max(pageSize.width * 0.04, 22);
+  const height = Math.max(pageSize.height * 0.03, 22);
+  const leftPercent = rect ? toNumber(rect.left) : 10;
+  const topPercent = rect ? toNumber(rect.top) : 10;
+  const x = clamp((leftPercent / 100) * pageSize.width, 0, pageSize.width - width);
+  const y = clamp((topPercent / 100) * pageSize.height, 0, pageSize.height - height);
+  return {
+    origin: { x, y },
+    size: { width, height },
+  };
+}
+
+function parseKonvaInkList(content: string, pageSize: Size): {
+  inkList: PdfInkListObject[];
+  strokeColor?: string;
+  strokeWidth?: number;
+} {
+  if (!content) return { inkList: [] };
+  try {
+    const stage = JSON.parse(content);
+    const attrs = stage?.attrs || {};
+    const stageWidth = toNumber(attrs.width);
+    const stageHeight = toNumber(attrs.height);
+    if (!stageWidth || !stageHeight) return { inkList: [] };
+
+    const layers = Array.isArray(stage?.children) ? stage.children : [];
+    const inkList = [] as PdfInkListObject[];
+    let strokeColor = "";
+    let strokeWidth = 1;
+
+    for (const layer of layers) {
+      const children = Array.isArray(layer?.children) ? layer.children : [];
+      for (const child of children) {
+        if (child?.className !== "Line") continue;
+        const childAttrs = child?.attrs || {};
+        if (childAttrs.globalCompositeOperation === "destination-out") continue;
+        const points = Array.isArray(childAttrs.points) ? childAttrs.points : [];
+        if (points.length < 4) continue;
+        const converted = [] as { x: number; y: number }[];
+        for (let i = 0; i < points.length - 1; i += 2) {
+          converted.push({
+            x: (toNumber(points[i]) / stageWidth) * pageSize.width,
+            y: (toNumber(points[i + 1]) / stageHeight) * pageSize.height,
+          });
+        }
+        inkList.push({ points: converted });
+        if (!strokeColor && typeof childAttrs.stroke === "string") {
+          strokeColor = childAttrs.stroke;
+        }
+        if (!strokeWidth && Number.isFinite(childAttrs.strokeWidth)) {
+          strokeWidth = toNumber(childAttrs.strokeWidth, 1);
+        }
+      }
+    }
+
+    return {
+      inkList,
+      strokeColor: strokeColor || undefined,
+      strokeWidth,
+    };
+  } catch {
+    return { inkList: [] };
+  }
+}
+
+function normalizeLegacyAnnotation(raw: AnnotationData): AnnotationData {
+  return {
+    ...raw,
+    pageNumber: toNumber(raw.pageNumber, 1),
+    rects: parseLegacyRects(raw.rects),
+  };
+}
+
+function supportedLegacyType(type: AnnotationType) {
+  return (
+    type === AnnotationType.HIGHLIGHT ||
+    type === AnnotationType.UNDERLINE ||
+    type === AnnotationType.STRIKEOUT ||
+    type === AnnotationType.RECTANGLE ||
+    type === AnnotationType.COMMENT ||
+    type === AnnotationType.INK
+  );
+}
+
+function normalizeSqlRow(row: Record<string, unknown>): AnnotationData {
+  return {
+    _id: String(row._id || ""),
+    timestampAdded: toNumber(row.timestampAdded, Date.now()),
+    timestampModified: toNumber(row.timestampModified, Date.now()),
+    dataType: "pdfAnnotation",
+    projectId: String(row.projectId || ""),
+    pageNumber: toNumber(row.pageNumber, 1),
+    content: String(row.content || ""),
+    color: String(row.color || ""),
+    rects: parseLegacyRects(row.rects as string | undefined),
+    type: String(row.type || AnnotationType.HIGHLIGHT) as AnnotationType,
+  };
+}
+
+export async function loadLegacyAnnotations(
+  projectId: string
+): Promise<AnnotationData[]> {
+  const normalized = [] as AnnotationData[];
+  const seen = new Set<string>();
+
+  const sqlRows =
+    (await sqldb.select<Record<string, unknown>[]>(
+      "SELECT * FROM annotations WHERE projectId = $1",
+      [projectId]
+    )) || [];
+
+  for (const row of sqlRows) {
+    const annotation = normalizeSqlRow(row);
+    if (!annotation._id || seen.has(annotation._id)) continue;
+    if (!supportedLegacyType(annotation.type)) continue;
+    seen.add(annotation._id);
+    normalized.push(annotation);
+  }
+
+  if (normalized.length > 0) return normalized;
+
+  const docs = ((await db.getDocs("pdfAnnotation")) || []) as AnnotationData[];
+  for (const doc of docs) {
+    if (!doc || doc.projectId !== projectId) continue;
+    const annotation = normalizeLegacyAnnotation(doc);
+    if (!annotation._id || seen.has(annotation._id)) continue;
+    if (!supportedLegacyType(annotation.type)) continue;
+    seen.add(annotation._id);
+    normalized.push(annotation);
+  }
+  return normalized;
+}
+
+export function legacyToEmbedAnnotation(
+  legacyAnnotation: AnnotationData,
+  document: PdfDocumentObject
+): PdfAnnotationObject | null {
+  const annotation = normalizeLegacyAnnotation(legacyAnnotation);
+  const pageIndex = annotation.pageNumber - 1;
+  const pageSize = pageSizeFor(document, pageIndex);
+  if (!pageSize) return null;
+  const color = normalizeColor(annotation.color);
+  const legacyRects = annotation.rects || [];
+  const segmentRects = legacyRects.map((rect) =>
+    legacyRectPercentToPdfRect(rect, pageSize)
+  );
+  const defaultRect: PdfRect = {
+    origin: { x: pageSize.width * 0.1, y: pageSize.height * 0.1 },
+    size: { width: pageSize.width * 0.2, height: pageSize.height * 0.03 },
+  };
+  const rect = unionRects(segmentRects) || defaultRect;
+  const base = {
+    id: annotation._id,
+    pageIndex,
+    rect,
+    contents: annotation.content || undefined,
+    custom: {
+      source: LEGACY_ANNOTATION_SOURCE,
+      legacyAnnotationId: annotation._id,
+    },
+  };
+
+  switch (annotation.type) {
+    case AnnotationType.HIGHLIGHT:
+      return {
+        ...base,
+        type: PdfAnnotationSubtype.HIGHLIGHT,
+        strokeColor: color,
+        opacity: 0.35,
+        segmentRects: segmentRects.length ? segmentRects : [rect],
+      };
+    case AnnotationType.UNDERLINE:
+      return {
+        ...base,
+        type: PdfAnnotationSubtype.UNDERLINE,
+        strokeColor: color,
+        opacity: 1,
+        segmentRects: segmentRects.length ? segmentRects : [rect],
+      };
+    case AnnotationType.STRIKEOUT:
+      return {
+        ...base,
+        type: PdfAnnotationSubtype.STRIKEOUT,
+        strokeColor: color,
+        opacity: 1,
+        segmentRects: segmentRects.length ? segmentRects : [rect],
+      };
+    case AnnotationType.RECTANGLE:
+      return {
+        ...base,
+        type: PdfAnnotationSubtype.SQUARE,
+        color,
+        opacity: 0.2,
+        strokeWidth: 1,
+        strokeColor: color,
+        strokeStyle: PdfAnnotationBorderStyle.SOLID,
+        flags: ["print"],
+      };
+    case AnnotationType.COMMENT:
+      return {
+        ...base,
+        type: PdfAnnotationSubtype.TEXT,
+        rect: defaultCommentRect(pageSize, legacyRects[0]),
+        contents: annotation.content || "",
+        color,
+        opacity: 1,
+        icon: PdfAnnotationIcon.Note,
+      };
+    case AnnotationType.INK: {
+      const { inkList, strokeColor, strokeWidth } = parseKonvaInkList(
+        annotation.content,
+        pageSize
+      );
+      if (!inkList.length) return null;
+      return {
+        ...base,
+        type: PdfAnnotationSubtype.INK,
+        inkList,
+        strokeColor: strokeColor || color,
+        opacity: 1,
+        strokeWidth: strokeWidth || 1,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+function embedTypeToLegacyType(type: PdfAnnotationSubtype): AnnotationType | null {
+  switch (type) {
+    case PdfAnnotationSubtype.HIGHLIGHT:
+      return AnnotationType.HIGHLIGHT;
+    case PdfAnnotationSubtype.UNDERLINE:
+      return AnnotationType.UNDERLINE;
+    case PdfAnnotationSubtype.STRIKEOUT:
+      return AnnotationType.STRIKEOUT;
+    case PdfAnnotationSubtype.SQUARE:
+      return AnnotationType.RECTANGLE;
+    case PdfAnnotationSubtype.TEXT:
+      return AnnotationType.COMMENT;
+    case PdfAnnotationSubtype.INK:
+      return AnnotationType.INK;
+    default:
+      return null;
+  }
+}
+
+export function embedToLegacyAnnotation(
+  annotation: PdfAnnotationObject,
+  projectId: string,
+  document: PdfDocumentObject
+): AnnotationData | null {
+  const legacyType = embedTypeToLegacyType(annotation.type);
+  if (!legacyType) return null;
+  const pageIndex = annotation.pageIndex;
+  const pageSize = pageSizeFor(document, pageIndex);
+  if (!pageSize) return null;
+
+  let rects = [] as Rect[];
+  if (
+    annotation.type === PdfAnnotationSubtype.HIGHLIGHT ||
+    annotation.type === PdfAnnotationSubtype.UNDERLINE ||
+    annotation.type === PdfAnnotationSubtype.STRIKEOUT
+  ) {
+    const segmentRects = annotation.segmentRects || [];
+    rects = segmentRects.map((rect) => pdfRectToLegacyPercentRect(rect, pageSize));
+  } else {
+    rects = [pdfRectToLegacyPercentRect(annotation.rect, pageSize)];
+  }
+
+  const content =
+    legacyType === AnnotationType.INK
+      ? JSON.stringify({
+          inkList:
+            annotation.type === PdfAnnotationSubtype.INK
+              ? annotation.inkList || []
+              : [],
+        })
+      : annotation.contents || "";
+
+  const color =
+    annotation.type === PdfAnnotationSubtype.INK ||
+    annotation.type === PdfAnnotationSubtype.HIGHLIGHT ||
+    annotation.type === PdfAnnotationSubtype.UNDERLINE ||
+    annotation.type === PdfAnnotationSubtype.STRIKEOUT
+      ? annotation.strokeColor || annotation.color || "#ffff00"
+      : annotation.color || annotation.strokeColor || "#ffff00";
+
+  return {
+    _id: annotation.id,
+    timestampAdded: Date.now(),
+    timestampModified: Date.now(),
+    dataType: "pdfAnnotation",
+    projectId,
+    pageNumber: pageIndex + 1,
+    content,
+    color,
+    rects,
+    type: legacyType,
+  };
+}
+
+export async function saveLegacyAnnotation(annotation: AnnotationData) {
+  const now = Date.now();
+  let timestampAdded = annotation.timestampAdded;
+  try {
+    const existing = (await db.get(annotation._id)) as AnnotationData;
+    timestampAdded = existing.timestampAdded;
+  } catch {
+    timestampAdded = annotation.timestampAdded || now;
+  }
+
+  const next = {
+    ...annotation,
+    timestampAdded,
+    timestampModified: now,
+    dataType: "pdfAnnotation" as const,
+  };
+
+  await db.put(next);
+  await sqldb.execute("DELETE FROM annotations WHERE _id = $1", [next._id]);
+  await sqldb.execute(
+    `INSERT INTO annotations (projectId, _id, type, rects, color, pageNumber, content, timestampAdded, timestampModified)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+    [
+      next.projectId,
+      next._id,
+      next.type,
+      next.rects,
+      next.color,
+      next.pageNumber,
+      next.content,
+      next.timestampAdded,
+      next.timestampModified,
+    ]
+  );
+}
+
+export async function deleteLegacyAnnotation(annotationId: string) {
+  try {
+    const existing = await db.get(annotationId);
+    await db.remove(existing);
+  } catch {
+    // already removed from json storage
+  }
+  await sqldb.execute("DELETE FROM annotations WHERE _id = $1", [annotationId]);
+}
+
+export function shouldMigrateLegacyType(type: AnnotationType) {
+  return MARKUP_TYPES.has(type) || type === AnnotationType.RECTANGLE || type === AnnotationType.COMMENT || type === AnnotationType.INK;
+}

--- a/src/components/pdfreader/PDFReader.vue
+++ b/src/components/pdfreader/PDFReader.vue
@@ -1,626 +1,320 @@
 <template>
-  <q-splitter
-    class="PDF-reader"
-    v-model="rightMenuSize"
-    :separator-class="{ 'q-splitter-separator': showRightMenu }"
-    :disable="!showRightMenu"
-    reverse
-    :limits="[0, 60]"
-    @update:model-value="(size) => resizeRightMenu(size)"
-  >
-    <template v-slot:before>
-      <PDFToolBar
-        class="PDF-toolbar"
-        :pdfState="pdfApp.state"
-        :pageLabels="pdfApp.pageLabels"
-        :matchesCount="pdfApp.matchesCount"
-        v-model:showRightMenu="showRightMenu"
+  <div class="pdf-reader">
+    <div
+      v-if="loading"
+      class="state"
+    >
+      <q-circular-progress
+        indeterminate
+        rounded
+        color="primary"
+        size="xl"
       />
-      <div
-        ref="viewerContainer"
-        class="viewerContainer"
-      >
-        <div class="pdfViewer"></div>
-        <div
-          v-if="!initialized"
-          style="position: relative; top: 50%"
-          class="text-center"
-        >
-          <q-circular-progress
-            indeterminate
-            rounded
-            color="primary"
-            size="xl"
-          />
-        </div>
-        <AnnotCard
-          v-if="showAnnotCard && pdfApp.annotStore.selected"
-          :style="style"
-          :annot="(pdfApp.annotStore.selected as Annotation)"
-          ref="card"
-        />
-        <FloatingMenu
-          v-if="showFloatingMenu"
-          :style="style"
-          :projectid="props.projectId"
-          @highlightText="(color: string) => highlightText(color)"
-        />
-      </div>
-      <PeekCard
-        v-for="link in pdfApp.peekManager.links"
-        :key="link.id"
-        :link="link"
-        :peekManager="pdfApp.peekManager"
-        :darkMode="pdfApp.state.darkMode"
-      />
-    </template>
-    <template v-slot:after>
-      <RightMenu />
-    </template>
-  </q-splitter>
+    </div>
+    <div
+      v-else-if="errorMessage"
+      class="state error"
+    >
+      {{ errorMessage }}
+    </div>
+    <PDFViewer
+      v-else-if="viewerConfig"
+      :key="sourceUrl"
+      class="embedpdf-viewer"
+      :config="viewerConfig"
+      @ready="onViewerReady"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">
-import { PDFPageView } from "pdfjs-dist/web/pdf_viewer";
-import {
-  AnnotationData,
-  AnnotationType,
-  PageType,
-  Project,
-  Rect,
-} from "src/backend/database";
-import { computed, nextTick, onMounted, provide, ref, watch } from "vue";
-import { KEY_pdfApp, KEY_project } from "./injectKeys";
-
-import AnnotCard from "./AnnotCard.vue";
-import FloatingMenu from "./FloatingMenu.vue";
-import PDFToolBar from "./PDFToolBar.vue";
-import PeekCard from "./PeekCard.vue";
-import RightMenu from "./RightMenu.vue";
-import { QSplitter, throttle } from "quasar";
-import { db } from "src/backend/database";
-import { Annotation, Ink } from "src/backend/pdfannotation/annotations";
-import PDFApplication from "src/backend/pdfreader";
+import { convertFileSrc } from "@tauri-apps/api/tauri";
+import { PDFViewer } from "@embedpdf/vue-pdf-viewer";
+import type {
+  PdfAnnotationObject,
+  PdfDocumentObject,
+  PluginRegistry,
+} from "@embedpdf/vue-pdf-viewer";
+import type { Project } from "src/backend/database";
 import { getProject } from "src/backend/project";
-import { useLayoutStore } from "src/stores/layoutStore";
-import { useProjectStore } from "src/stores/projectStore";
-const layoutStore = useLayoutStore();
+import {
+  LEGACY_ANNOTATION_SOURCE,
+  deleteLegacyAnnotation,
+  embedToLegacyAnnotation,
+  legacyToEmbedAnnotation,
+  loadLegacyAnnotations,
+  saveLegacyAnnotation,
+  shouldMigrateLegacyType,
+} from "src/backend/pdfreader/embedAnnotationMigration";
+import { onBeforeUnmount, computed, ref, watch } from "vue";
 
-/**********************************
- * Props, Data, and component refs
- **********************************/
 const props = defineProps({
   projectId: { type: String, required: true },
   focusAnnotId: { type: String, required: false },
 });
 
-const initialized = ref(false);
+const loading = ref(false);
+const sourceUrl = ref("");
+const errorMessage = ref("");
+const viewerRegistry = ref<PluginRegistry | null>(null);
 
-// viewer containers
-const viewerContainer = ref<HTMLDivElement>();
+let clearViewerSubscriptions: Array<() => void> = [];
+let importingLegacy = false;
 
-// ready to save data
-const project = ref<Project>();
+type TrackedAnnotation = { object: PdfAnnotationObject };
+type AnnotationStateLike = { byUid: Record<string, TrackedAnnotation> };
+type AnnotationEventLike = {
+  type: "create" | "update" | "delete" | "loaded";
+  annotation: PdfAnnotationObject;
+  committed: boolean;
+};
+type AnnotationCapabilityLike = {
+  getState(documentId?: string): AnnotationStateLike;
+  importAnnotations(items: Array<{ annotation: PdfAnnotationObject }>): void;
+  selectAnnotation(pageIndex: number, annotationId: string): void;
+  onAnnotationEvent(listener: (event: AnnotationEventLike) => void): () => void;
+};
+type DocumentManagerCapabilityLike = {
+  getActiveDocument(): PdfDocumentObject | null;
+  onDocumentOpened(listener: () => void): () => void;
+};
+type ScrollCapabilityLike = {
+  scrollToPage(options: {
+    pageNumber: number;
+    pageCoordinates?: { x: number; y: number };
+    behavior?: "auto" | "smooth" | "instant";
+  }): void;
+};
 
-// right menu (don't use stateStore since there will be many readerPages)
-const rightMenuSize = ref(0);
-const prvRightMenuSize = ref(0);
-const showRightMenu = computed({
-  get() {
-    return rightMenuSize.value > 0;
-  },
-  set(visible: boolean) {
-    if (visible) {
-      rightMenuSize.value = Math.max(prvRightMenuSize.value, 40);
-    } else {
-      prvRightMenuSize.value = rightMenuSize.value;
-      rightMenuSize.value = 0;
-    }
-  },
-});
-
-// annot card & colorpicker
-const card = ref();
-const showAnnotCard = ref(false);
-const showFloatingMenu = ref(false);
-const selectionPage = ref(0);
-const style = ref("");
-
-// PDFApplicaiton
-const pdfApp = new PDFApplication(props.projectId);
-const renderEvt = ref<{
-  pageNumber: number;
-  source: PDFPageView;
-  error: Error | null;
-}>();
-
-/******************************
- * RightMenu
- ******************************/
-
-/**
- * Resizes the right-side menu based on user interaction with the splitter.
- * @param {number} size - The new size of the right menu.
- */
-function resizeRightMenu(size: number) {
-  if (size < 15) showRightMenu.value = false;
+function cleanupViewerSubscriptions() {
+  for (const clear of clearViewerSubscriptions) clear();
+  clearViewerSubscriptions = [];
 }
 
-/*******************************
- * AnnotCard & FloatingMenu
- *******************************/
-/**
- * Toggles the visibility of the floating menu for text selection actions.
- * The menu is positioned based on the page and selection coordinates.
- * @param {boolean} show - Flag indicating whether to show or hide the menu.
- * @param {number} [page] - The page number where the selection is made.
- */
-function toggleFloatingMenu(show: boolean, page?: number) {
-  if (!show) {
-    showFloatingMenu.value = false;
-  } else {
-    // if no page is given, that means no seleciton
-    if (!page) return;
-    selectionPage.value = page;
-
-    // find the selection on the page
-    let hasSelection = false;
-    let selection = window.getSelection();
-    if (selection === null) return;
-    let rects = [] as DOMRectList | DOMRect[];
-    if (!!selection.focusNode) {
-      rects = selection.getRangeAt(0).getClientRects();
-      if (rects.length > 1) {
-        hasSelection = true;
-      } else if (rects.length == 1 && rects[0].width > 1) {
-        hasSelection = true;
-      } else {
-        hasSelection = false;
-      }
-    }
-
-    if (hasSelection) {
-      showFloatingMenu.value = true;
-      setPosition(rects);
-    }
-  }
+function getCapability<T>(registry: PluginRegistry, pluginId: string): T | null {
+  const plugin = registry.getPlugin(pluginId) as
+    | { provides?: () => T }
+    | null;
+  if (!plugin || typeof plugin.provides !== "function") return null;
+  return plugin.provides();
 }
 
-/**
- * Toggles the annotation card visibility for displaying or editing annotations.
- * Positions the card based on the annotation's location on the page.
- * @param {boolean} show - Flag indicating whether to show or hide the annotation card.
- * @param {Annotation} [annot] - The annotation object for which the card is shown.
- */
-function toggleAnnotCard(show: boolean, annot?: Annotation) {
-  if (!show) {
-    showAnnotCard.value = false;
-  } else {
-    if (!annot) return;
-    setPosition(annot.doms.map((dom) => dom.getBoundingClientRect()));
-    showAnnotCard.value = true;
-    nextTick(() => {
-      enableDragToMoveAnnotCard();
-    });
-  }
-}
-
-/**
- * Sets the position of the floating menu or annotation card relative to the PDF viewer.
- * Calculates the position based on the provided DOMRect objects.
- * @param {DOMRect[] | DOMRectList} rects - The DOMRect objects representing the position of text selection or annotation.
- */
-function setPosition(rects: DOMRect[] | DOMRectList) {
-  if (!viewerContainer.value) return;
-  let viewer = viewerContainer.value.querySelector(
-    "div.pdfViewer"
-  ) as HTMLElement;
-  let bgRect = viewer.getBoundingClientRect();
-  let top = 0;
-  let mid = 0;
-  let n = 0; // number of non-empty rect
-  for (let rect of rects) {
-    if (rect.width < 0.1) continue;
-    top = Math.max(top, rect.bottom);
-    mid += (rect.left + rect.right) / 2;
-    n++;
-  }
-  mid /= n; // averaged mid point
-
-  style.value = `
-  background: var(--color-pdfreader-colorpicker-bkgd);
-  position: absolute;
-  left: ${mid - bgRect.left - 75}px;
-  top: ${top - bgRect.top + 20}px;
-  z-index: 100;
-  `;
-}
-
-/**
- * Enables dragging functionality for the annotation card, allowing it to be moved around the screen.
- */
-function enableDragToMoveAnnotCard() {
-  if (!card.value) return;
-  card.value.isMovable = true;
-  const cardEl = card.value.$el as HTMLElement;
-  const cardHandleEl = cardEl.firstChild as HTMLElement;
-  cardHandleEl.onmousedown = (e: MouseEvent) => {
-    let x = e.clientX;
-    let y = e.clientY;
-    let shiftX = 0;
-    let shiftY = 0;
-    let top = parseFloat(cardEl.style.top);
-    let left = parseFloat(cardEl.style.left);
-    const parentDiv = cardEl.parentElement as HTMLElement;
-    parentDiv.onmousemove = (ev: MouseEvent) => {
-      ev.preventDefault();
-      shiftX = ev.clientX - x;
-      shiftY = ev.clientY - y;
-      cardEl.style.left = `${left + shiftX}px`;
-      cardEl.style.top = `${top + shiftY}px`;
-    };
-
-    cardHandleEl.onmouseup = () => {
-      // cardHandleEl.onmousedown = null;
-      parentDiv.onmousemove = null;
-    };
+const viewerConfig = computed(() => {
+  if (!sourceUrl.value) return null;
+  return {
+    src: sourceUrl.value,
+    theme: {
+      preference: "system",
+    },
+    annotations: {
+      annotationAuthor: "Sophosia",
+    },
   };
-}
-
-/**
- * Highlights the selected text in the PDF document with the specified color.
- * Creates a new annotation for the highlighted text.
- * @param {string} color - The color to use for highlighting the text.
- */
-function highlightText(color: string) {
-  if (!renderEvt.value) return;
-  let annot = pdfApp.annotFactory.buildSelectionBasedAnnot(
-    AnnotationType.HIGHLIGHT,
-    color,
-    renderEvt.value
-  );
-  if (annot) {
-    pdfApp.annotStore.add(annot, true);
-    annot.draw(renderEvt.value);
-    let annotId = annot.data._id;
-    annot.doms.forEach((dom) => {
-      dom.onmousedown = () => pdfApp.annotStore.setActive(annotId);
-    });
-    annot.hasEvtHandler = true;
-  }
-  toggleFloatingMenu(false);
-}
-
-/***************************
- * PDF realated
- ***************************/
-/**
- * Loads a PDF into the viewer and initializes necessary states.
- * @param {string} projectId - The ID of the project associated with the PDF.
- */
-async function loadPDF(projectId: string) {
-  project.value = (await getProject(projectId, {
-    includePDF: true,
-  })) as Project;
-  if (!project.value.path) return;
-  // load state before loading pdf
-  await pdfApp.loadState(project.value._id);
-  await pdfApp.loadAnnotations();
-  await pdfApp.loadPDF(project.value.path);
-}
-
-/******************
- * Provides
- ******************/
-provide(KEY_project, project);
-provide(KEY_pdfApp, pdfApp);
-
-/***********************
- * Watchers
- ***********************/
-watch(pdfApp.state, (state) => {
-  // pdfState is reactive, so it's deep wather automatically
-  if (!pdfApp.ready.value) return;
-  pdfApp.saveState(state);
 });
+
+async function loadProjectPdf(projectId: string) {
+  loading.value = true;
+  errorMessage.value = "";
+  sourceUrl.value = "";
+
+  try {
+    const project = (await getProject(projectId, {
+      includePDF: true,
+    })) as Project | undefined;
+
+    if (!project?.path) {
+      errorMessage.value = "No PDF file found for this project.";
+      return;
+    }
+
+    sourceUrl.value = convertFileSrc(project.path);
+  } catch (error) {
+    console.error(error);
+    errorMessage.value = "Unable to load this PDF file.";
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function migrateLegacyAnnotationsForActiveDocument(
+  annotationCapability: AnnotationCapabilityLike,
+  documentManager: DocumentManagerCapabilityLike
+) {
+  const document = documentManager.getActiveDocument();
+  if (!document) return;
+
+  const legacyAnnotations = await loadLegacyAnnotations(props.projectId);
+  if (!legacyAnnotations.length) return;
+
+  const existing =
+    annotationCapability.getState(document.id)?.byUid ||
+    annotationCapability.getState()?.byUid ||
+    {};
+  const existingIds = new Set(Object.keys(existing));
+  const importItems = [] as Array<{ annotation: PdfAnnotationObject }>;
+
+  for (const annotation of legacyAnnotations) {
+    if (!shouldMigrateLegacyType(annotation.type)) continue;
+    if (!annotation._id || existingIds.has(annotation._id)) continue;
+    const converted = legacyToEmbedAnnotation(annotation, document);
+    if (!converted) continue;
+    importItems.push({ annotation: converted });
+  }
+
+  if (!importItems.length) return;
+  importingLegacy = true;
+  try {
+    annotationCapability.importAnnotations(importItems);
+  } finally {
+    importingLegacy = false;
+  }
+}
+
+async function syncAnnotationEventToLegacyStore(
+  event: AnnotationEventLike,
+  documentManager: DocumentManagerCapabilityLike
+) {
+  if (importingLegacy) return;
+  if (event.type === "loaded") return;
+  if (!event.annotation?.id) return;
+  if (!event.committed) return;
+
+  if (event.type === "delete") {
+    await deleteLegacyAnnotation(event.annotation.id);
+    return;
+  }
+
+  const document = documentManager.getActiveDocument();
+  if (!document) return;
+  const annotation = embedToLegacyAnnotation(
+    event.annotation,
+    props.projectId,
+    document
+  );
+  if (!annotation) return;
+  await saveLegacyAnnotation(annotation);
+}
+
+function focusAnnotationIfNeeded(
+  annotationCapability: AnnotationCapabilityLike,
+  scrollCapability: ScrollCapabilityLike | null
+) {
+  if (!props.focusAnnotId) return;
+  const state = annotationCapability.getState();
+  const target = state?.byUid?.[props.focusAnnotId];
+  if (!target?.object) return;
+
+  const annotation = target.object;
+  annotationCapability.selectAnnotation(annotation.pageIndex, annotation.id);
+  if (scrollCapability) {
+    scrollCapability.scrollToPage({
+      pageNumber: annotation.pageIndex + 1,
+      pageCoordinates: {
+        x: annotation.rect.origin.x,
+        y: annotation.rect.origin.y,
+      },
+      behavior: "smooth",
+    });
+  }
+}
+
+async function onViewerReady(registry: PluginRegistry) {
+  viewerRegistry.value = registry;
+  cleanupViewerSubscriptions();
+
+  const annotationCapability = getCapability<AnnotationCapabilityLike>(
+    registry,
+    "annotation"
+  );
+  const documentManager = getCapability<DocumentManagerCapabilityLike>(
+    registry,
+    "document-manager"
+  );
+  const scrollCapability = getCapability<ScrollCapabilityLike>(registry, "scroll");
+  if (!annotationCapability || !documentManager) return;
+
+  const migrateAndFocus = async () => {
+    await migrateLegacyAnnotationsForActiveDocument(
+      annotationCapability,
+      documentManager
+    );
+    focusAnnotationIfNeeded(annotationCapability, scrollCapability);
+  };
+
+  clearViewerSubscriptions.push(
+    documentManager.onDocumentOpened(async () => {
+      await migrateAndFocus();
+    })
+  );
+
+  clearViewerSubscriptions.push(
+    annotationCapability.onAnnotationEvent(async (event) => {
+      if (
+        event.annotation?.custom?.source === LEGACY_ANNOTATION_SOURCE &&
+        importingLegacy
+      ) {
+        return;
+      }
+      await syncAnnotationEventToLegacyStore(event, documentManager);
+    })
+  );
+
+  await migrateAndFocus();
+}
+
+watch(
+  () => props.projectId,
+  async (projectId) => {
+    cleanupViewerSubscriptions();
+    viewerRegistry.value = null;
+    await loadProjectPdf(projectId);
+  },
+  { immediate: true }
+);
 
 watch(
   () => props.focusAnnotId,
   () => {
-    // scroll to annot when focusAnnotId changes
-    if (props.focusAnnotId) pdfApp.scrollAnnotIntoView(props.focusAnnotId);
+    const registry = viewerRegistry.value;
+    if (!registry) return;
+    const annotationCapability = getCapability<AnnotationCapabilityLike>(
+      registry,
+      "annotation"
+    );
+    const scrollCapability = getCapability<ScrollCapabilityLike>(registry, "scroll");
+    if (!annotationCapability) return;
+    focusAnnotationIfNeeded(annotationCapability, scrollCapability);
   }
 );
 
-/**************************************************
- * Implement eventhandlers and init PDFApplication
- **************************************************/
-onMounted(async () => {
-  initialized.value = false;
-  if (!viewerContainer.value) return;
-  pdfApp.init(viewerContainer.value as HTMLDivElement);
-
-  // scroll to annot when pages are ready
-  pdfApp.eventBus?.on("pagesinit", () => {
-    if (props.focusAnnotId) pdfApp.scrollAnnotIntoView(props.focusAnnotId);
-  });
-  pdfApp.eventBus?.on(
-    "annotationeditorlayerrendered",
-    async (e: {
-      error: Error | null;
-      pageNumber: number;
-      source: PDFPageView;
-    }) => {
-      // draw annotations on active page
-      let annots = pdfApp.annotStore.getByPage(e.pageNumber);
-      let inkAnnot: Ink | undefined = undefined;
-      let clickedAnnotId: string;
-      for (let annot of annots) {
-        // draw annotations (create Konva stage if it's ink)
-        annot.draw(e);
-        if (annot.data.type === AnnotationType.INK) {
-          // bind event handlers to Konva stage
-          inkAnnot = annot as Ink;
-          inkAnnot.bindEventHandlers(pdfApp.state);
-        } else {
-          // bind event handlers to doms
-          if (
-            annot.data.type === AnnotationType.RECTANGLE ||
-            annot.data.type === AnnotationType.COMMENT
-          )
-            annot.enableDragToMove();
-        }
-      }
-
-      // monitor tool change and create konva stage as needed
-      e.source.div.onmousemove = throttle(() => {
-        if (
-          pdfApp.state.tool === AnnotationType.INK ||
-          pdfApp.state.tool === AnnotationType.ERASER
-        ) {
-          // in freedraw mose
-          if (!inkAnnot) {
-            // create canvas if there is none
-            let annotData = {
-              _id: `SA${db.nanoid}`,
-              timestampAdded: Date.now(),
-              timestampModified: Date.now(),
-              dataType: "pdfAnnotation",
-              projectId: props.projectId,
-              pageNumber: e.pageNumber,
-              content: "",
-              color: "",
-              rects: [] as Rect[],
-              type: AnnotationType.INK,
-            } as AnnotationData;
-            let annot = pdfApp.annotFactory.build(annotData);
-            if (annot) {
-              pdfApp.annotStore.add(annot, true);
-              inkAnnot = annot as Ink;
-              inkAnnot.draw(e);
-              inkAnnot.bindEventHandlers(pdfApp.state);
-            }
-          }
-          inkAnnot?.setDrawable(true);
-        } else {
-          inkAnnot?.setDrawable(false);
-        }
-      }, 500);
-
-      // event handlers to handle user interactions
-      e.source.div.onmousedown = (ev: MouseEvent) => {
-        toggleAnnotCard(false);
-        toggleFloatingMenu(false);
-        // if clicking on an annotation, set it active and return;
-        clickedAnnotId =
-          (ev.target as HTMLElement).getAttribute("annotation-id") ||
-          ((ev.target as HTMLElement).parentNode as HTMLElement).getAttribute(
-            "annotation-id"
-          ) ||
-          "";
-        pdfApp.annotStore.setActive(clickedAnnotId);
-        if (clickedAnnotId) {
-          e.source.div.onmouseup = () => {
-            toggleAnnotCard(true, pdfApp.annotStore.selected as Annotation);
-          };
-          return;
-        } else {
-          // set the props.focusAnnotId to ""
-          // so that user can reselect the annotation by clicking a link in note
-          // need to better way to do this
-          if (project.value) {
-            layoutStore.openPage({
-              id: project.value._id,
-              type: PageType.ReaderPage,
-              label: project.value.label,
-            });
-          }
-        }
-
-        // otherwise continue to determine what user is doing
-        switch (pdfApp.state.tool) {
-          case AnnotationType.CURSOR:
-            e.source.div.onmouseup = () => {
-              toggleFloatingMenu(true, e.pageNumber);
-              renderEvt.value = e;
-            };
-            break;
-          case AnnotationType.HIGHLIGHT:
-          case AnnotationType.UNDERLINE:
-          case AnnotationType.STRIKEOUT:
-            e.source.div.onmouseup = () => {
-              let annot = pdfApp.annotFactory.buildSelectionBasedAnnot(
-                pdfApp.state.tool,
-                pdfApp.state.color,
-                e
-              );
-              if (annot) {
-                pdfApp.annotStore.add(annot, true);
-                annot.draw(e);
-              }
-            };
-            break;
-          case AnnotationType.RECTANGLE:
-            let canvasWrapper = e.source.div.querySelector(
-              ".canvasWrapper"
-            ) as HTMLElement;
-            // temporary rectangle for rectangular highlight
-            let x1 = ev.clientX;
-            let y1 = ev.clientY;
-            let layerRect = canvasWrapper.getBoundingClientRect();
-            let tempRect = document.createElement("div");
-            tempRect.style.position = "absolute";
-            tempRect.style.background = pdfApp.state.color;
-            tempRect.style.mixBlendMode = "multiply";
-            tempRect.style.left = `${x1 - layerRect.x}px`;
-            tempRect.style.top = `${y1 - layerRect.y}px`;
-            canvasWrapper.append(tempRect);
-
-            e.source.div.onmousemove = (ev: MouseEvent) => {
-              ev.preventDefault();
-              if (!tempRect) return;
-              tempRect.style.width = `${ev.clientX - x1}px`;
-              tempRect.style.height = `${ev.clientY - y1}px`;
-            };
-            e.source.div.onmouseup = (ev: MouseEvent) => {
-              tempRect.remove();
-              // create annotation
-              let rects = [
-                {
-                  left: Math.min(x1, ev.clientX),
-                  top: Math.min(y1, ev.clientY),
-                  width: Math.abs(x1 - ev.clientX),
-                  height: Math.abs(y1 - ev.clientY),
-                },
-              ];
-              if (rects[0].width < 1 || rects[0].height < 1) return;
-              rects[0] = pdfApp.annotFactory.offsetTransform(
-                rects[0],
-                canvasWrapper
-              );
-
-              let annotData = {
-                _id: `SA${db.nanoid}`,
-                timestampAdded: Date.now(),
-                timestampModified: Date.now(),
-                type: AnnotationType.RECTANGLE,
-                rects: rects,
-                color: pdfApp.state.color,
-                pageNumber: e.pageNumber,
-                projectId: pdfApp.state.projectId,
-                dataType: "pdfAnnotation",
-                content: "",
-              } as AnnotationData;
-              let annot = pdfApp.annotFactory.build(annotData);
-              if (annot) {
-                annot.draw(e);
-                annot.enableDragToMove();
-                pdfApp.annotStore.add(annot, true);
-              }
-              e.source.div.onmousemove = null;
-              e.source.div.onmouseup = null;
-            };
-            break;
-          case AnnotationType.COMMENT:
-            e.source.div.onmouseup = (ev: MouseEvent) => {
-              let canvasWrapper = e.source.div.querySelector(
-                ".canvasWrapper"
-              ) as HTMLElement;
-              // create annotation
-              let rects = [
-                {
-                  left: ev.clientX,
-                  top: ev.clientY,
-                  width: 0,
-                  height: 0,
-                },
-              ];
-              rects[0] = pdfApp.annotFactory.offsetTransform(
-                rects[0],
-                canvasWrapper
-              );
-              let annotData = {
-                _id: `SA${db.nanoid}`,
-                timestampAdded: Date.now(),
-                timestampModified: Date.now(),
-                type: AnnotationType.COMMENT,
-                rects: rects,
-                color: pdfApp.state.color,
-                pageNumber: e.pageNumber,
-                projectId: pdfApp.state.projectId,
-                dataType: "pdfAnnotation",
-                content: "",
-              } as AnnotationData;
-              let annot = pdfApp.annotFactory.build(annotData);
-              if (annot) {
-                annot.draw(e);
-                annot.enableDragToMove();
-                pdfApp.annotStore.add(annot, true);
-              }
-              // return to cursor after comment is placed
-              pdfApp.changeTool(AnnotationType.CURSOR);
-            };
-            break;
-        }
-      };
-    }
-  );
-
-  await loadPDF(props.projectId);
-  initialized.value = true;
+onBeforeUnmount(() => {
+  cleanupViewerSubscriptions();
+  viewerRegistry.value = null;
 });
 </script>
-<style lang="scss">
-@use "pdfjs-dist/web/pdf_viewer.css";
 
-.viewerContainer {
+<style lang="scss" scoped>
+.pdf-reader {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: var(--color-pdfreader-viewer-bkgd);
+}
+
+.embedpdf-viewer {
+  width: 100%;
+  height: 100%;
+}
+
+.state {
   position: absolute;
-  overflow: auto;
-  // toolbar: 36px
-  height: calc(100% - 36px);
-  top: 36px;
-  width: calc(100% - 10px); // so the right scroll bar does not touch right edge
-  background-color: var(--color-pdfreader-viewer-bkgd);
-  // enable selections
-  user-select: auto;
-  -moz-user-select: auto;
-  -ms-user-select: auto;
-  -webkit-user-select: text;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.page {
-  // fix no gap between pages
-  box-sizing: unset;
-}
-
-.hidden,
-[hidden] {
-  // fix pdfjs-dist 3.7.107 standard annot popup won't hidden
-  display: none !important;
-}
-
-.activeAnnotation {
-  outline-offset: 3px;
-  outline: dashed 2px $primary;
-}
-
-// fix popup not correctly rendered
-.annotationLayer .popup {
-  // fix white text color in standard annotations
-  // standard annotation means annotation made by adobe pdf etc
-  color: black;
-}
-
-.annotationLayer .popup h1 {
-  // fix weird title in standard annotation
-  font-weight: bold;
-  line-height: unset;
-  letter-spacing: unset;
-}
-
-// .annotationEditorLayer will be hidden if there is no pdfjs-generated annotation
-// do not hide user injected annotations
-.annotationEditorLayer {
-  display: unset !important;
+.error {
+  color: var(--q-negative, #c10015);
 }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,6 +338,301 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@embedpdf/core@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/core/-/core-2.6.1.tgz#7f19f98a931ca11938950cff6b0072577b3f9e0b"
+  integrity sha512-v0g6/L493IeUlV8fcI/Ry6vJTk5h4/AErA1Gy6HyG5MUBE2wJjjtY3laDLnB12vSseeUEuAt1eCwgXe3eJA8mA==
+  dependencies:
+    "@embedpdf/engines" "2.6.1"
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/engines@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/engines/-/engines-2.6.1.tgz#3187fd5d4f5f3a21a531f080f468079a93d2b0e4"
+  integrity sha512-yxJdW3L7vTO8SbFYp4+cdFlGzfXhh5+6Adj1nbhqgHYKg/cza5iLtqAJvmnwCWnt8e3EpdAjQ9ZdiifdxSDtuw==
+  dependencies:
+    "@embedpdf/fonts-arabic" "1.0.0"
+    "@embedpdf/fonts-hebrew" "1.0.0"
+    "@embedpdf/fonts-jp" "1.0.0"
+    "@embedpdf/fonts-kr" "1.0.0"
+    "@embedpdf/fonts-latin" "1.0.0"
+    "@embedpdf/fonts-sc" "1.0.0"
+    "@embedpdf/fonts-tc" "1.0.0"
+    "@embedpdf/models" "2.6.1"
+    "@embedpdf/pdfium" "2.6.1"
+
+"@embedpdf/fonts-arabic@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@embedpdf/fonts-arabic/-/fonts-arabic-1.0.0.tgz#32cf6e9b13a73827800278db7ae832981f9764df"
+  integrity sha512-SnGvQb+LwPZQO2WjjvlmXrJZolJUfLYbLZQSaYUw1vrQyMyJKT4LewvJGG+hZ+Yz2fz7OMIQ+4Gc98mGODZtOg==
+
+"@embedpdf/fonts-hebrew@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@embedpdf/fonts-hebrew/-/fonts-hebrew-1.0.0.tgz#5ad24258c1606fa95dbb4ba5fa67757502c58edc"
+  integrity sha512-5HVAKGL7VqPeTxxADDrSqAFBxfmAXdP8fIqrPwJIKkqdK2643bOer8CqnnpO3/nPoFhkzxhttWMB9BGiqSW62w==
+
+"@embedpdf/fonts-jp@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@embedpdf/fonts-jp/-/fonts-jp-1.0.0.tgz#03c643bde1e0e556bfa1cf4bbb7eafbe555aa9ac"
+  integrity sha512-BY2tv/mcICUUKf+M/bizf3RU65PMqKClJ/e5o9mgMibxyML0OQvEDwYMRPODQkKgJKXCO3ScHmVvcmXp6kt+fA==
+
+"@embedpdf/fonts-kr@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@embedpdf/fonts-kr/-/fonts-kr-1.0.0.tgz#4652ae3b26a83c3c7e499f0b7b60375fb9bb1d46"
+  integrity sha512-bh88HXSvOBS581kgmihWY7Ijp9hBsvlmXogFG5LSNx9UBAobRcakZiFMGieRBc06hUSkpo7WhjaFM/z/SfQ8dQ==
+
+"@embedpdf/fonts-latin@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@embedpdf/fonts-latin/-/fonts-latin-1.0.0.tgz#b646560c2c147f0ccbf04ae26ef18c7822506240"
+  integrity sha512-LLYysdr8O6sRNzhmW3PbF3AeA8xnqvOi4XLFfIfNlW5uEZ+qsJdcfd78Q78sFJMhlaOAYFMziMMsnOzmx463rA==
+
+"@embedpdf/fonts-sc@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@embedpdf/fonts-sc/-/fonts-sc-1.0.0.tgz#a52a70b3cb36e9e49148f2055f51d0fa387f41bf"
+  integrity sha512-ETXl7XCwaQLSSvMO3EUDwMNqtL64kX2LlFxarTRi/NsIGGOIxUurGfKtrkmtnKHrWy1jAJSt6oxK2uJhvdvQIw==
+
+"@embedpdf/fonts-tc@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@embedpdf/fonts-tc/-/fonts-tc-1.0.0.tgz#21262bb512ede384c3fb84b952a6812b98e793f4"
+  integrity sha512-rGZJbVD6DYS5BbXdpEMnWkpVF0Knar+bsiyb2o3+YRx7O8eyFubEBQUSUInirQk69HA6fc3GhYCg7TyC/oD76Q==
+
+"@embedpdf/models@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/models/-/models-2.6.1.tgz#042506d2040e0e3b7dde5985ee4fe9bf1e525428"
+  integrity sha512-lwZJx4GdEfF8PJJ7VBQs8vTRjmRlD8PYONCURQ5gB1gJczgEg6Xp0YnGnf777FC8NTu2yZ74bWdoKNNLc5Th6Q==
+
+"@embedpdf/pdfium@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/pdfium/-/pdfium-2.6.1.tgz#283888845e6535c8c9f2f17f956b5244ea29952c"
+  integrity sha512-yd9tftD+Vb3a4EyUdkO/GYbSSg/hCMD54Qlq30YQclminAfDUm5o8z1bOZH5sLjrFjlgPvkVJJIdup7w9Vy4hA==
+
+"@embedpdf/plugin-annotation@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-annotation/-/plugin-annotation-2.6.1.tgz#36ed5be9896542be1eb8051a3d8e5064367d89e3"
+  integrity sha512-J4tszS5VVWNzff29Q3HXAskQNH1TOnIDuS/O+IUf4cRrXnKPRL1in3EgyUoBL9mgvbcXFvMRfMB+9NqA8iZfLg==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+    "@embedpdf/utils" "2.6.1"
+
+"@embedpdf/plugin-attachment@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-attachment/-/plugin-attachment-2.6.1.tgz#8eed3e7d2cdb188a8fdd2910bb12b8ad56adc465"
+  integrity sha512-bLniF6AVHD/gRYVb1wiRveZp4a5fDffAfQ2/OBTi69vEgnTbV5GVGFCa+sjNun6FrN5dMwielG3WDjmc4xT+vQ==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-bookmark@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-bookmark/-/plugin-bookmark-2.6.1.tgz#cf7fc92017fd34c617dd63273979ce5bbb638779"
+  integrity sha512-LS2DuuH4uJ8RD7E19xYT/7IgyKCgs0PqCHPm5Qsqh5cz/MW4Nx5i/GY0JB9HwfEK+JnrpX2C6aWeq5WwwvT/jw==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-capture@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-capture/-/plugin-capture-2.6.1.tgz#ed9603f9495007c758acc02e270f5c2e35e9bb12"
+  integrity sha512-4B3D5pifN1UmKuMp1Ez9u+CDrPKwMqe7sOC5jVzVdgNsr2Nzm/k8WDyBqqr1lqtAOQ3qgziO/sZFipYw5Y8E5Q==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-commands@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-commands/-/plugin-commands-2.6.1.tgz#ffbb59fc2251d801faa4de81a4c77b91553198c8"
+  integrity sha512-37Tk6EYaxmsgUiACEWn1KPy4zEWppZ75dBSnkbA5RaNUlq/R3Ui8PGFia5UureQs6P7Q9/sDjY8X8/q82f+6AA==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-document-manager@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-document-manager/-/plugin-document-manager-2.6.1.tgz#12527d1bf592de821ee0bb011655923545240a79"
+  integrity sha512-0kVvwyAmB86FD8RLiKVgo7ElVq1xickl14XGihQIcqI5b4NFwo458BN9nWAjba0CvaFIpUMM4s6HjRwgqzoMCw==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-export@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-export/-/plugin-export-2.6.1.tgz#adb4301884aafa9da321f3bff1e07de308b82be5"
+  integrity sha512-tUUTre7C7xWz5BGWZlyoXvreWjgYudFWg4g6TVgQrUMbB7+Pyk+lJjtyBeK60BhV/LEob9CSYukeBkdpx1IFCA==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-fullscreen@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-fullscreen/-/plugin-fullscreen-2.6.1.tgz#79d29a071f3c4e058693f243b24a4934e25ec955"
+  integrity sha512-qnON59V7aN12+OZxNfWPah8SiqR+UKSaLNT3oItZSVN1DKHEU7l349BlIVS0TcMkYHbWFsAXQ7InAfm948/1Fg==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-history@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-history/-/plugin-history-2.6.1.tgz#e693fca65c5df414c0bcda64530a1dab0505ca28"
+  integrity sha512-FIoXCxVSABIR+BhdImNyeBm+dIK9Q+7DPCIonnoe8m/9d3CaqFXGrVu4+/FqFzkPnVo7XbegAt7TzfY/c+0QEw==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-i18n@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-i18n/-/plugin-i18n-2.6.1.tgz#ded1037c1c73257d0289d0e98a15318c861d987b"
+  integrity sha512-aqM+rrIgipI9+5arh8iSeG5ji758NUni3CpINKRsNrJp5llN5JAWdT8qNwOFEbkEuMlnyk7UETAWs6nG/LfYZQ==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-interaction-manager@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-interaction-manager/-/plugin-interaction-manager-2.6.1.tgz#472ed19e55e1edfb7b5b74baa4c1bcc5f50f2701"
+  integrity sha512-Zr5h68fkL+diEekXMlYh2AIJnf29P33IMhTHaMDWw7Cy7SktPNcy4zwH0tPVrkIijmp/tN4/Oy3xpcy9YA44mw==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-pan@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-pan/-/plugin-pan-2.6.1.tgz#92dd1406a24f3ded0acdf6cdc129ec16c90b836a"
+  integrity sha512-Kpa715ASWEajDVcHSoqlH55U1sxG89CpCpaJ8BBGs2qdFDNnkDobfRMGHE7Z89zMAhVNuAOkSOxj3q7xLrCNjw==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-print@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-print/-/plugin-print-2.6.1.tgz#d256aca00a7320335b9bf443b993791daaff0bc0"
+  integrity sha512-yvNcqSgQjXiU27wn/Vi1vtxtu1Jj3yFizHEwvzbK8sAwFSiOuGu1OpuZuzYuRbgN9pJzF93gxO4LlNo2SMxacQ==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-redaction@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-redaction/-/plugin-redaction-2.6.1.tgz#0328594cd00b3c3012a2012c47a0747866ba3b0a"
+  integrity sha512-InJFyu2dzGuIGlldYkRnFRLbvYD0WrQIw1TgJtY/wC35OZggMEeCow6WAuLa0Spl41sndAoTEYUgvMcJI1LhOQ==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+    "@embedpdf/utils" "2.6.1"
+
+"@embedpdf/plugin-render@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-render/-/plugin-render-2.6.1.tgz#df70b77ddb9d7cce75903f968f5f6d793981d770"
+  integrity sha512-6MtdkDLDXRZxpDx2AQP1QrlLf90VL/88atNTYVnTCAmPghE6UuOMZ8iXWcyfOI/5KRxEXBIoKJWisLn3PjztEQ==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-rotate@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-rotate/-/plugin-rotate-2.6.1.tgz#7597acaf6127c3dd816f389df4af88aa649cda18"
+  integrity sha512-iZQxnIrHPh29/bcMkaR3U7cqP/8D99b9crYFZ7k1qWEQ97XKEq5tnxAZbtnn/UpkcwyIbmpMInrLLGd8iucmRA==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-scroll@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-scroll/-/plugin-scroll-2.6.1.tgz#be4f00a15848b0f10c04854588a8ff8cfbb72b19"
+  integrity sha512-tqOFvaNdLx/tyqsBcJXYFlsS28TFgkfLS996szCo0zAmXH0dd1AahWNxKldlTCyMGk6XV6KET+GvDn6/OB1RsA==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-search@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-search/-/plugin-search-2.6.1.tgz#d5ca2ac67161db7c795cd0a43f6db8a822dd5223"
+  integrity sha512-a1EpQyC4sCTmZ+6SxfO7Q8Xsj6U8Of5FXKbkt5FgRC8U5AS42f9qJft6YXE6T/xBmHhSFabmmepZM9dbop5XtA==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-selection@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-selection/-/plugin-selection-2.6.1.tgz#44d2928168557fda4fdee3d364fa746d96b04af0"
+  integrity sha512-Cjn25JjAjV6/50n72qFr6cRlDdiIdl8CYKxpM1jWkADvVhZLFhOBut9KFkxsJ5Zhb2JGrZp5WYVQDBTpGcB/ZQ==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+    "@embedpdf/utils" "2.6.1"
+
+"@embedpdf/plugin-spread@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-spread/-/plugin-spread-2.6.1.tgz#9a30914f4a36a1819294c0fb11f3d4339e4a69f2"
+  integrity sha512-Pnsew6hn8JLmbOWcEgmVuWGa19nWuxRmQ/h/drBsyE+Jb7L1jcac8dwfrflvw57CrA6jvw6MNUsZgGyzLdIcqg==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-thumbnail@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-thumbnail/-/plugin-thumbnail-2.6.1.tgz#c828139cb1cf64b3e7a4c87dda85277b1e0e1044"
+  integrity sha512-D336HO6UwM+xZCHvJ12eK5JiN3+OpC3lE4sbtfc2cxV8XmzgkAB80s8ADJr41mskTt7ilHIvMU6Z+95StTyKEQ==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-tiling@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-tiling/-/plugin-tiling-2.6.1.tgz#4926f19873e926906ada4bdfca1d208f43fe7a24"
+  integrity sha512-bxuR+I+mWLgZpv7GoRlzL2sLNalSVkyrmxvW8VeYbogdneo9m2Tn8E4oxF0D9LsaKI8VYzISgdKc+BK0O7Uqhg==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-ui@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-ui/-/plugin-ui-2.6.1.tgz#9e475789964ca8618838183c5c356176498e9ce9"
+  integrity sha512-nBtkCZJxGPjl/8tJFFQDhMPZ5M/2KHO9+vCpZGa8wTCYuFpnE4XA+o9Zyt0UaUbgAtCNi/c7gzqbme+hdvvVmg==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-viewport@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-viewport/-/plugin-viewport-2.6.1.tgz#2cc0fa46e5d7e1cbfdb68128abe72c9d66de4b6b"
+  integrity sha512-CuLacNCGjVi1YsMTFNdR5ZT2opNysQbvvrhfSkFOxMrE8A3+7nEo4Eot6rQsr4qIHJiH3FwET7V4XHc1LuC3yw==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/plugin-zoom@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/plugin-zoom/-/plugin-zoom-2.6.1.tgz#98429944fc4e41fd7955b182aa8014f946280385"
+  integrity sha512-D3EQBp9wWU0yH1KSTlrs9/MsQETMqLXUrbW3k7DPyt92XMd8nekG+Y++TG89nIf7sa7Y7zD/OhcbyZyN2bX8vA==
+  dependencies:
+    "@embedpdf/models" "2.6.1"
+
+"@embedpdf/snippet@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/snippet/-/snippet-2.6.1.tgz#0086abfd9a8bf61f726a1549bff671dd1fdc155c"
+  integrity sha512-GQVvrL1m1667yomY6cO5ySjrhYBT2aH+0WceTRs2qw2gm8b+G2bqdpAyLkqp5N/GGvxJf9XBANlteqtCwEMhmA==
+  dependencies:
+    "@embedpdf/core" "2.6.1"
+    "@embedpdf/engines" "2.6.1"
+    "@embedpdf/models" "2.6.1"
+    "@embedpdf/pdfium" "2.6.1"
+    "@embedpdf/plugin-annotation" "2.6.1"
+    "@embedpdf/plugin-attachment" "2.6.1"
+    "@embedpdf/plugin-bookmark" "2.6.1"
+    "@embedpdf/plugin-capture" "2.6.1"
+    "@embedpdf/plugin-commands" "2.6.1"
+    "@embedpdf/plugin-document-manager" "2.6.1"
+    "@embedpdf/plugin-export" "2.6.1"
+    "@embedpdf/plugin-fullscreen" "2.6.1"
+    "@embedpdf/plugin-history" "2.6.1"
+    "@embedpdf/plugin-i18n" "2.6.1"
+    "@embedpdf/plugin-interaction-manager" "2.6.1"
+    "@embedpdf/plugin-pan" "2.6.1"
+    "@embedpdf/plugin-print" "2.6.1"
+    "@embedpdf/plugin-redaction" "2.6.1"
+    "@embedpdf/plugin-render" "2.6.1"
+    "@embedpdf/plugin-rotate" "2.6.1"
+    "@embedpdf/plugin-scroll" "2.6.1"
+    "@embedpdf/plugin-search" "2.6.1"
+    "@embedpdf/plugin-selection" "2.6.1"
+    "@embedpdf/plugin-spread" "2.6.1"
+    "@embedpdf/plugin-thumbnail" "2.6.1"
+    "@embedpdf/plugin-tiling" "2.6.1"
+    "@embedpdf/plugin-ui" "2.6.1"
+    "@embedpdf/plugin-viewport" "2.6.1"
+    "@embedpdf/plugin-zoom" "2.6.1"
+    preact "^10.17.0"
+    tailwind-merge "^3.4.0"
+
+"@embedpdf/utils@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/utils/-/utils-2.6.1.tgz#be8f8d6342f2c38bb153962df282cb2d1e7655e3"
+  integrity sha512-bZiuinb5C/lYGUuR1ObwbU2xfRT/+qidlX6TWqPcS8YcUtcw9qlrs9dJCApxh7bLSO2qOEtvLlThj4XGIlkHUw==
+
+"@embedpdf/vue-pdf-viewer@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@embedpdf/vue-pdf-viewer/-/vue-pdf-viewer-2.6.1.tgz#a1198f48e388d4bfadd991d84dd11ae04c4253a5"
+  integrity sha512-PLYVRypZRgve+8I3WANzU+j4ZzPuHsuuUXA89iQ/HoDdAML74jnCi5gE3wFIdWqGh1L7yFppewAnftpXAKe+Tw==
+  dependencies:
+    "@embedpdf/snippet" "2.6.1"
+
 "@esbuild/aix-ppc64@0.21.5":
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
@@ -894,63 +1189,6 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
-"@supabase/auth-js@2.65.0":
-  version "2.65.0"
-  resolved "https://registry.yarnpkg.com/@supabase/auth-js/-/auth-js-2.65.0.tgz#e345c492f8cbc31cd6289968eae0e349ff0f39e9"
-  integrity sha512-+wboHfZufAE2Y612OsKeVP4rVOeGZzzMLD/Ac3HrTQkkY4qXNjI6Af9gtmxwccE5nFvTiF114FEbIQ1hRq5uUw==
-  dependencies:
-    "@supabase/node-fetch" "^2.6.14"
-
-"@supabase/functions-js@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@supabase/functions-js/-/functions-js-2.4.1.tgz#373e75f8d3453bacd71fb64f88d7a341d7b53ad7"
-  integrity sha512-8sZ2ibwHlf+WkHDUZJUXqqmPvWQ3UHN0W30behOJngVh/qHHekhJLCFbh0AjkE9/FqqXtf9eoVvmYgfCLk5tNA==
-  dependencies:
-    "@supabase/node-fetch" "^2.6.14"
-
-"@supabase/node-fetch@2.6.15", "@supabase/node-fetch@^2.6.14":
-  version "2.6.15"
-  resolved "https://registry.yarnpkg.com/@supabase/node-fetch/-/node-fetch-2.6.15.tgz#731271430e276983191930816303c44159e7226c"
-  integrity sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
-"@supabase/postgrest-js@1.16.1":
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/@supabase/postgrest-js/-/postgrest-js-1.16.1.tgz#68dfa0581d8ae4296378cb8815bbde3f4602aef5"
-  integrity sha512-EOSEZFm5pPuCPGCmLF1VOCS78DfkSz600PBuvBND/IZmMciJ1pmsS3ss6TkB6UkuvTybYiBh7gKOYyxoEO3USA==
-  dependencies:
-    "@supabase/node-fetch" "^2.6.14"
-
-"@supabase/realtime-js@2.10.2":
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/@supabase/realtime-js/-/realtime-js-2.10.2.tgz#c2b42d17d723d2d2a9146cfad61dc3df1ce3127e"
-  integrity sha512-qyCQaNg90HmJstsvr2aJNxK2zgoKh9ZZA8oqb7UT2LCh3mj9zpa3Iwu167AuyNxsxrUE8eEJ2yH6wLCij4EApA==
-  dependencies:
-    "@supabase/node-fetch" "^2.6.14"
-    "@types/phoenix" "^1.5.4"
-    "@types/ws" "^8.5.10"
-    ws "^8.14.2"
-
-"@supabase/storage-js@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@supabase/storage-js/-/storage-js-2.7.0.tgz#9ff322d2c3b141087aa34115cf14205e4980ce75"
-  integrity sha512-iZenEdO6Mx9iTR6T7wC7sk6KKsoDPLq8rdu5VRy7+JiT1i8fnqfcOr6mfF2Eaqky9VQzhP8zZKQYjzozB65Rig==
-  dependencies:
-    "@supabase/node-fetch" "^2.6.14"
-
-"@supabase/supabase-js@^2.42.0":
-  version "2.45.4"
-  resolved "https://registry.yarnpkg.com/@supabase/supabase-js/-/supabase-js-2.45.4.tgz#0bcf8722f1732dfe3e4c5190d23e3938dcc689c3"
-  integrity sha512-E5p8/zOLaQ3a462MZnmnz03CrduA5ySH9hZyL03Y+QZLIOO4/Gs8Rdy4ZCKDHsN7x0xdanVEWWFN3pJFQr9/hg==
-  dependencies:
-    "@supabase/auth-js" "2.65.0"
-    "@supabase/functions-js" "2.4.1"
-    "@supabase/node-fetch" "2.6.15"
-    "@supabase/postgrest-js" "1.16.1"
-    "@supabase/realtime-js" "2.10.2"
-    "@supabase/storage-js" "2.7.0"
-
 "@tauri-apps/api@1.6.0", "@tauri-apps/api@^1.5.3":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@tauri-apps/api/-/api-1.6.0.tgz#745b7e4e26782c3b2ad9510d558fa5bb2cf29186"
@@ -1191,11 +1429,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
-"@types/phoenix@^1.5.4":
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/@types/phoenix/-/phoenix-1.6.5.tgz#5654e14ec7ad25334a157a20015996b6d7d2075e"
-  integrity sha512-xegpDuR+z0UqG9fwHqNoy3rI7JDlvaPh2TY47Fl80oq6g+hXT+c/LEuE43X48clZ6lOfANl5WrPur9fYO1RJ/w==
-
 "@types/prop-types@*":
   version "15.7.13"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.13.tgz#2af91918ee12d9d32914feb13f5326658461b451"
@@ -1250,13 +1483,6 @@
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.8.tgz#518609aefb797da19bf222feb199e8f653ff7627"
   integrity sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==
-
-"@types/ws@^8.5.10":
-  version "8.5.12"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.12.tgz#619475fe98f35ccca2a2f6c137702d85ec247b7e"
-  integrity sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==
-  dependencies:
-    "@types/node" "*"
 
 "@types/yauzl@^2.9.1":
   version "2.10.3"
@@ -5225,6 +5451,11 @@ postcss@^8.4.13, postcss@^8.4.43, postcss@^8.4.47:
     picocolors "^1.1.0"
     source-map-js "^1.2.1"
 
+preact@^10.17.0:
+  version "10.28.4"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.28.4.tgz#8ffab01c5c0590535bdaecdd548801f44c6e483a"
+  integrity sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -6028,6 +6259,11 @@ table@^6.8.0:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
+tailwind-merge@^3.4.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-3.5.0.tgz#06502f4496ba15151445d97d916a26564d50d1ca"
+  integrity sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==
+
 tar-stream@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
@@ -6674,11 +6910,6 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
-
-ws@^8.14.2:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This replaces src/components/pdfreader/PDFReader.vue with an EmbedPDF-based viewer and keeps project PDF loading/focus handling in the new flow. It adds a legacy annotation migration bridge that imports existing annotations into EmbedPDF and syncs create/update/delete events back to legacy storage for current users. It adds @embedpdf/vue-pdf-viewer (and lockfile updates) and acknowledges EmbedPDF in both README files. Targeted ESLint for the touched reader/migration files and a Quasar production build both pass.