### PR TITLE
Fix sidebar font sizes and layout stability

### DIFF
--- a/src/components/layout/Stack.vue
+++ b/src/components/layout/Stack.vue
@@ -1,7 +1,6 @@
 <template>
   <!-- the class stack is only for searching -->
   <TabContainer
-    v-if="stack.children.length > 0"
     class="tab-container"
     :enableCrossWindowDragAndDrop="enableCrossWindowDragAndDrop"
     :pages="stack.children"
@@ -15,11 +14,11 @@
       :enableCrossWindowDragAndDrop="enableCrossWindowDragAndDrop"
       @moveToStack="(page: Page, pos: 'center' | 'left' | 'right'| 'top' | 'bottom', fromWindow: string) => moveToStack(page, pos, fromWindow)"
     />
+    <EmptyStack
+      v-else
+      @openPage="(page) => layoutStore.openPage(page)"
+    />
   </div>
-  <EmptyStack
-    v-if="stack.children.length === 0"
-    @openPage="(page) => layoutStore.openPage(page)"
-  />
 </template>
 <script setup lang="ts">
 import { listen } from "@tauri-apps/api/event";

--- a/src/components/leftmenu/GraphView.vue
+++ b/src/components/leftmenu/GraphView.vue
@@ -5,7 +5,7 @@
         <div class="square"></div>
         <div
           class="q-ml-xs"
-          style="font-size: 1rem"
+          style="font-size: 0.875rem"
         >
           {{ $t("project") }}
         </div>
@@ -14,7 +14,7 @@
         <div class="circle"></div>
         <div
           class="q-ml-xs"
-          style="font-size: 1rem"
+          style="font-size: 0.875rem"
         >
           {{ $t("note") }}
         </div>
@@ -23,7 +23,7 @@
         <div class="triangle"></div>
         <div
           class="q-ml-xs"
-          style="font-size: 1rem"
+          style="font-size: 0.875rem"
         >
           {{ $t("annotation") }}
         </div>

--- a/src/components/leftmenu/ProjectTree.vue
+++ b/src/components/leftmenu/ProjectTree.vue
@@ -139,7 +139,7 @@
         </div>
         <div
           v-else
-          style="width: calc(100% - 1.4rem); font-size: 1rem"
+          style="width: calc(100% - 1.4rem); font-size: 0.875rem"
           class="ellipsis non-selectable"
           :type="prop.node.dataType"
         >

--- a/src/components/library/CategoryTree.vue
+++ b/src/components/library/CategoryTree.vue
@@ -108,7 +108,7 @@
           </div>
           <div
             v-else
-            style="font-size: 1rem; width: calc(100% - 1.5rem)"
+            style="font-size: 0.875rem; width: calc(100% - 1.5rem)"
             class="ellipsis"
           >
             {{

--- a/src/layouts/UnifiedSidebar.vue
+++ b/src/layouts/UnifiedSidebar.vue
@@ -50,11 +50,21 @@
         <BookStack width="18" height="18" />
         <q-tooltip>{{ $t("library") }}</q-tooltip>
       </q-btn>
+    </div>
+    <div class="sidebar-content">
+      <ProjectNavigator />
+      <PluginView
+        v-for="view in pluginManager.getViews(Component.LeftMenu)"
+        :key="view.id"
+        :mount="view.mount"
+      />
+    </div>
+    <div class="sidebar-bottom-row">
       <q-btn
-        class="sidebar-icon-btn"
+        class="sidebar-bottom-btn"
         flat
-        square
-        padding="xs"
+        no-caps
+        padding="xs sm"
         @click="
           $emit('openPage', {
             id: 'workspace',
@@ -63,9 +73,11 @@
           })
         "
       >
-        <Folder width="18" height="18" />
+        <Folder width="16" height="16" class="q-mr-xs" />
+        <span class="sidebar-bottom-label">{{ $t("workspace") }}s</span>
         <q-tooltip>{{ $t("workspace") }}</q-tooltip>
       </q-btn>
+      <div class="sidebar-icon-spacer" />
       <q-btn
         class="sidebar-icon-btn"
         flat
@@ -86,7 +98,7 @@
           }
         "
       >
-        <HelpCircle width="18" height="18" />
+        <HelpCircle width="16" height="16" />
         <q-tooltip>{{ $t("help") }}</q-tooltip>
       </q-btn>
       <q-btn
@@ -102,17 +114,9 @@
           })
         "
       >
-        <Settings width="18" height="18" />
+        <Settings width="16" height="16" />
         <q-tooltip>{{ $t("settings") }}</q-tooltip>
       </q-btn>
-    </div>
-    <div class="sidebar-content">
-      <ProjectNavigator />
-      <PluginView
-        v-for="view in pluginManager.getViews(Component.LeftMenu)"
-        :key="view.id"
-        :mount="view.mount"
-      />
     </div>
   </div>
 </template>
@@ -182,5 +186,31 @@ defineEmits(["openPage"]);
   overflow: hidden;
   display: flex;
   flex-direction: column;
+}
+
+.sidebar-bottom-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 2px;
+  padding: 10px 10px;
+  flex-shrink: 0;
+  border-top: 1px solid var(--q-border);
+}
+
+.sidebar-bottom-btn {
+  border-radius: 6px;
+  color: var(--q-text-muted);
+  font-size: 0.8125rem;
+  transition: color 0.15s ease, background-color 0.15s ease;
+
+  &:hover {
+    color: var(--q-reg-text);
+    background: var(--q-hover);
+  }
+}
+
+.sidebar-bottom-label {
+  font-weight: 500;
 }
 </style>


### PR DESCRIPTION
## Summary
- Reduced sidebar item font sizes from 1rem to 0.875rem (ProjectTree, CategoryTree, GraphView) for consistent typography across the UI
- Fixed layout stability issue where TabContainer was conditionally rendered, causing visual shift when opening the first page
- Reorganized sidebar with new bottom action bar containing Workspace, Help, and Settings controls
- Improved spacing and visual hierarchy with increased bottom bar height

## Test Plan
- [ ] Verify sidebar text (files, categories, graph items) displays at correct font size
- [ ] Open Settings/Help/Workspace from welcome screen - confirm no loading bar or visual flashing
- [ ] Check bottom sidebar bar displays correctly with proper spacing and height
- [ ] Verify Workspaces label displays correctly (plural form)

🤖 Generated with [Claude Code](https://claude.com/claude-code)