### PR TITLE
Refactor UI: extract shared logic, fix sidebar sync, convert settings tabs

### DIFF
--- a/src/components/dialogs/DeleteDialog.vue
+++ b/src/components/dialogs/DeleteDialog.vue
@@ -5,57 +5,53 @@
     no-shake
     @hide="deleteDialog.close()"
   >
-    <q-card class="dialog">
-      <q-card-section>
-        <div
-          v-if="deleteDialog.isDeleteFromDB"
-          class="text-h6"
-        >
-          {{ $t("permenantly-delete") }}
-        </div>
-        <div
-          v-else
-          class="text-h6"
-        >
-          {{ $t("delete") }}
-        </div>
+    <q-card class="dialog delete-dialog">
+      <q-card-section class="dialog-header">
+        <span class="dialog-title">
+          {{ deleteDialog.isDeleteFromDB ? $t("permenantly-delete") : $t("delete") }}
+        </span>
       </q-card-section>
-      <q-card-section class="q-pt-none">
-        <strong>
+      <q-card-section class="dialog-body">
+        <p class="dialog-text">
           {{ $t("are-you-sure-you-want-to-delete-the-following-project") }}
-        </strong>
-        <ul>
-          <li v-for="project in deleteDialog.deleteProjects">
-            "{{ getTitle(project, settingStore.showTranslatedTitle) }}"
+        </p>
+        <ul class="delete-list">
+          <li
+            v-for="project in deleteDialog.deleteProjects"
+            :key="project._id"
+          >
+            {{ getTitle(project, settingStore.showTranslatedTitle) }}
           </li>
         </ul>
-        <strong v-if="deleteDialog.isDeleteFromDB">
-          <div>{{ $t("this-operation-is-not-reversible") }}</div>
-          <div>{{ $t("notes-in-this-project-will-be-deleted") }}</div>
-        </strong>
+        <div
+          v-if="deleteDialog.isDeleteFromDB"
+          class="delete-warning"
+        >
+          <p>{{ $t("this-operation-is-not-reversible") }}</p>
+          <p>{{ $t("notes-in-this-project-will-be-deleted") }}</p>
+        </div>
       </q-card-section>
-      <q-card-actions align="right">
+      <q-card-actions class="dialog-actions">
         <q-btn
           flat
           square
-          v-close-popup
           :ripple="false"
+          class="dialog-btn"
+          :label="$t('cancel')"
+          v-close-popup
           @click="deleteDialog.close()"
           data-cy="btn-cancel"
-        >
-          {{ $t("cancel") }}
-        </q-btn>
+        />
         <q-btn
           flat
           square
-          v-close-popup
           :ripple="false"
+          class="dialog-btn dialog-btn--danger"
+          :label="$t('confirm')"
+          v-close-popup
           @click="deleteDialog.confirm()"
-          color="negative"
           data-cy="btn-confirm"
-        >
-          {{ $t("confirm") }}
-        </q-btn>
+        />
       </q-card-actions>
     </q-card>
   </q-dialog>
@@ -66,3 +62,35 @@ import { useSettingStore } from "src/stores/settingStore";
 import { deleteDialog } from "./dialogController";
 const settingStore = useSettingStore();
 </script>
+<style lang="scss" scoped>
+.delete-dialog {
+  min-width: 420px;
+}
+
+.delete-list {
+  margin: 8px 0;
+  padding-left: 20px;
+  color: var(--q-reg-text);
+  font-size: 0.875rem;
+
+  li {
+    padding: 2px 0;
+  }
+}
+
+.delete-warning {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: rgba(248, 113, 113, 0.08);
+  border: 1px solid rgba(248, 113, 113, 0.2);
+
+  p {
+    margin: 0;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--q-negative);
+    line-height: 1.5;
+  }
+}
+</style>

--- a/src/components/dialogs/DialogContainer.vue
+++ b/src/components/dialogs/DialogContainer.vue
@@ -6,6 +6,7 @@
   <ErrorDialog />
   <SuccessDialog />
   <ProgressDialog />
+  <NameDialog />
 </template>
 <script setup lang="ts">
 import DeleteDialog from "./DeleteDialog.vue";
@@ -14,5 +15,6 @@ import ExportDialog from "./ExportDialog.vue";
 import IdentifierDialog from "./IdentifierDialog.vue";
 import ImportDialog from "./ImportDialog.vue";
 import ProgressDialog from "./ProgressDialog.vue";
+import NameDialog from "./NameDialog.vue";
 import SuccessDialog from "./SuccessDialog.vue";
 </script>

--- a/src/components/dialogs/ErrorDialog.vue
+++ b/src/components/dialogs/ErrorDialog.vue
@@ -22,7 +22,7 @@
         </div>
       </q-card-section>
       <q-card-section class="dialog-body">
-        <p class="dialog-text">{{ errorDialog.error?.message || "" }}</p>
+        <p class="dialog-text" data-cy="error-msg">{{ errorDialog.error?.message || "" }}</p>
       </q-card-section>
       <q-card-actions class="dialog-actions">
         <q-btn

--- a/src/components/dialogs/ErrorDialog.vue
+++ b/src/components/dialogs/ErrorDialog.vue
@@ -6,32 +6,30 @@
     no-shake
     @hide="errorDialog.close()"
   >
-    <q-card class="dialog">
-      <q-card-section>
-        <div class="text-h6 row items-center">
-          <q-icon
-            :name="
-              errorDialog.type === 'error'
-                ? 'error_outline'
-                : 'warning_amber'
-            "
-            :color="errorDialog.type === 'error' ? 'negative' : 'warning'"
-            style="font-size: 1.5rem"
-          />
-          {{ $t(errorDialog.error?.name || "") }}
+    <q-card class="dialog error-dialog">
+      <q-card-section class="dialog-header">
+        <div class="error-title-row">
+          <div
+            class="error-icon"
+            :class="errorDialog.type"
+          >
+            <q-icon
+              :name="errorDialog.type === 'error' ? 'error_outline' : 'warning_amber'"
+              size="18px"
+            />
+          </div>
+          <span class="dialog-title">{{ $t(errorDialog.error?.name || "") }}</span>
         </div>
       </q-card-section>
-      <q-card-section
-        class="q-pt-none"
-        data-cy="error-msg"
-      >
-        {{ errorDialog.error?.message || "" }}
+      <q-card-section class="dialog-body">
+        <p class="dialog-text">{{ errorDialog.error?.message || "" }}</p>
       </q-card-section>
-      <q-card-actions align="right">
+      <q-card-actions class="dialog-actions">
         <q-btn
           flat
-          dense
+          square
           :ripple="false"
+          class="dialog-btn"
           label="OK"
           @click="errorDialog.close()"
           data-cy="btn-ok"
@@ -43,3 +41,34 @@
 <script setup lang="ts">
 import { errorDialog } from "src/components/dialogs/dialogController";
 </script>
+<style lang="scss" scoped>
+.error-dialog {
+  min-width: 380px;
+}
+
+.error-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.error-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  flex-shrink: 0;
+
+  &.error {
+    background: rgba(248, 113, 113, 0.12);
+    color: var(--q-negative);
+  }
+
+  &.warning {
+    background: rgba(251, 191, 36, 0.12);
+    color: #fbbf24;
+  }
+}
+</style>

--- a/src/components/dialogs/ExportDialog.vue
+++ b/src/components/dialogs/ExportDialog.vue
@@ -3,15 +3,14 @@
     v-model="exportDialog.visible"
     @hide="exportDialog.close()"
   >
-    <q-card class="export-dialog dialog">
-      <q-card-section>
-        <div class="text-h6">{{ $t("options") }}</div>
+    <q-card class="dialog export-dialog">
+      <q-card-section class="dialog-header">
+        <span class="dialog-title">{{ $t("options") }}</span>
       </q-card-section>
-      <q-card-section class="q-pt-none">
-        <div class="row items-center">
-          <div class="col-auto">Format:</div>
+      <q-card-section class="dialog-body">
+        <div class="export-field">
+          <label class="field-label">Format</label>
           <q-select
-            class="q-ml-sm col"
             outlined
             dense
             options-dense
@@ -19,9 +18,13 @@
             v-model="exportDialog.format"
             data-cy="format-select"
           />
-
+        </div>
+        <div
+          v-if="exportDialog.format.value === 'bibliography'"
+          class="export-field"
+        >
+          <label class="field-label">Template</label>
           <q-select
-            v-if="exportDialog.format.value === 'bibliography'"
             outlined
             dense
             options-dense
@@ -31,18 +34,22 @@
           />
         </div>
       </q-card-section>
-      <q-card-actions align="right">
+      <q-card-actions class="dialog-actions">
         <q-btn
           flat
           square
-          label="cancel"
+          :ripple="false"
+          class="dialog-btn"
+          :label="$t('cancel')"
           @click="exportDialog.close()"
           data-cy="btn-cancel"
         />
         <q-btn
           flat
           square
-          label="confirm"
+          :ripple="false"
+          class="dialog-btn"
+          :label="$t('confirm')"
           @click="exportDialog.confirm()"
           data-cy="btn-confirm"
         />
@@ -53,3 +60,26 @@
 <script setup lang="ts">
 import { exportDialog } from "./dialogController";
 </script>
+<style lang="scss" scoped>
+.export-dialog {
+  min-width: 380px;
+}
+
+.export-field {
+  margin-bottom: 12px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.field-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--q-text-muted);
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+</style>

--- a/src/components/dialogs/IdentifierDialog.vue
+++ b/src/components/dialogs/IdentifierDialog.vue
@@ -3,21 +3,17 @@
     v-model="identifierDialog.visible"
     @hide="identifierDialog.close()"
   >
-    <q-card
-      class="identifier-dialog dialog"
-      square
-    >
-      <q-card-section>
-        <div class="text-h6">
+    <q-card class="dialog identifier-dialog">
+      <q-card-section class="dialog-header">
+        <span class="dialog-title">
           <i18n-t keypath="search">
             <template #type>{{ $t("identifier") }}</template>
           </i18n-t>
-        </div>
+        </span>
       </q-card-section>
-      <q-card-section class="q-pt-none">
+      <q-card-section class="dialog-body">
         <q-input
           outlined
-          square
           dense
           autofocus
           class="full-width"
@@ -27,23 +23,25 @@
           data-cy="identifier-input"
         />
       </q-card-section>
-      <q-card-actions align="right">
+      <q-card-actions class="dialog-actions">
         <q-btn
           flat
           square
-          v-close-popup
           :ripple="false"
+          class="dialog-btn"
           :label="$t('cancel')"
+          v-close-popup
           @click="identifierDialog.close()"
           data-cy="btn-cancel"
         />
         <q-btn
           flat
           square
-          v-close-popup
           :ripple="false"
+          class="dialog-btn"
           :label="$t('confirm')"
           :disable="!identifierDialog.identifier"
+          v-close-popup
           @click="identifierDialog.confirm()"
           data-cy="btn-confirm"
         />

--- a/src/components/dialogs/ImportDialog.vue
+++ b/src/components/dialogs/ImportDialog.vue
@@ -1,35 +1,38 @@
 <template>
-  <q-dialog v-model="importDialog.visible">
-    <q-card
-      square
-      class="import-dialog dialog"
-    >
-      <q-card-section>
-        <div class="text-h6">{{ $t("import-collection") }}</div>
+  <q-dialog
+    v-model="importDialog.visible"
+    @hide="importDialog.close()"
+  >
+    <q-card class="dialog import-dialog">
+      <q-card-section class="dialog-header">
+        <span class="dialog-title">{{ $t("import-collection") }}</span>
       </q-card-section>
-      <q-card-section class="q-pt-none">
+      <q-card-section class="dialog-body">
         <q-checkbox
           dense
           v-model="importDialog.isCreateFolder"
           :label="$t('create-a-new-folder-for-this-collection')"
+          class="import-checkbox"
         />
       </q-card-section>
-      <q-card-actions align="right">
+      <q-card-actions class="dialog-actions">
         <q-btn
           flat
           square
-          v-close-popup
           :ripple="false"
+          class="dialog-btn"
           :label="$t('cancel')"
+          v-close-popup
           @click="importDialog.close()"
           data-cy="btn-cancel"
         />
         <q-btn
           flat
           square
-          v-close-popup
           :ripple="false"
+          class="dialog-btn"
           :label="$t('confirm')"
+          v-close-popup
           @click="importDialog.confirm()"
           data-cy="btn-confirm"
         />
@@ -37,7 +40,11 @@
     </q-card>
   </q-dialog>
 </template>
-
 <script setup lang="ts">
 import { importDialog } from "./dialogController";
 </script>
+<style lang="scss" scoped>
+.import-checkbox {
+  font-size: 0.875rem;
+}
+</style>

--- a/src/components/dialogs/NameDialog.vue
+++ b/src/components/dialogs/NameDialog.vue
@@ -1,0 +1,73 @@
+<template>
+  <q-dialog
+    v-model="nameDialog.visible"
+    @hide="nameDialog.close()"
+  >
+    <q-card class="dialog name-dialog">
+      <q-card-section class="dialog-header">
+        <span class="dialog-title">{{ nameDialog.title }}</span>
+      </q-card-section>
+      <q-card-section class="dialog-body">
+        <q-input
+          outlined
+          dense
+          autofocus
+          class="full-width"
+          :placeholder="nameDialog.placeholder"
+          v-model.trim="nameDialog.name"
+          @update:model-value="checkName"
+          @keydown.enter="onEnter"
+          :color="nameDialog.isDuplicate ? 'negative' : ''"
+          :bottom-slots="nameDialog.isDuplicate"
+        >
+          <template v-slot:hint v-if="nameDialog.isDuplicate">
+            <span class="duplicate-hint">{{ $t("duplicate") }}</span>
+          </template>
+        </q-input>
+      </q-card-section>
+      <q-card-actions class="dialog-actions">
+        <q-btn
+          flat
+          square
+          v-close-popup
+          :ripple="false"
+          class="dialog-btn"
+          :label="$t('cancel')"
+          @click="nameDialog.close()"
+        />
+        <q-btn
+          flat
+          square
+          :ripple="false"
+          class="dialog-btn"
+          :label="$t('confirm')"
+          :disable="!nameDialog.name || nameDialog.isDuplicate"
+          @click="nameDialog.confirm()"
+        />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+<script setup lang="ts">
+import { nameDialog } from "src/components/dialogs/dialogController";
+
+function checkName() {
+  nameDialog.isDuplicate = nameDialog.validateName(nameDialog.name);
+}
+
+function onEnter() {
+  if (nameDialog.name && !nameDialog.isDuplicate) {
+    nameDialog.confirm();
+  }
+}
+</script>
+<style lang="scss" scoped>
+.name-dialog {
+  min-width: 400px;
+}
+
+.duplicate-hint {
+  color: var(--q-negative);
+  font-size: 0.75rem;
+}
+</style>

--- a/src/components/dialogs/ProgressDialog.vue
+++ b/src/components/dialogs/ProgressDialog.vue
@@ -3,44 +3,51 @@
     v-model="progressDialog.visible"
     persistent
   >
-    <q-card class="progress-dialog dialog">
-      <q-card-section>
-        <div class="text-h6">{{ $t("progress") }}</div>
+    <q-card class="dialog progress-dialog">
+      <q-card-section class="dialog-header">
+        <span class="dialog-title">{{ $t("progress") }}</span>
       </q-card-section>
-      <q-card-section class="q-pt-none">
-        <q-linear-progress
-          size="1rem"
-          :value="progressDialog.progress"
-          animation-speed="0"
-        >
-          <div class="absolute-full flex flex-center">
-            <q-badge color="transparent">
-              {{ Math.round(progressDialog.progress * 100) }} %
-            </q-badge>
-          </div>
-        </q-linear-progress>
+      <q-card-section class="dialog-body">
+        <div class="progress-bar-wrapper">
+          <q-linear-progress
+            size="6px"
+            rounded
+            :value="progressDialog.progress"
+            animation-speed="0"
+            color="primary"
+            track-color="transparent"
+            class="progress-bar"
+          />
+          <span class="progress-percent">
+            {{ Math.round(progressDialog.progress * 100) }}%
+          </span>
+        </div>
         <div
           v-for="(error, index) in progressDialog.errors"
           :key="index"
-          class="text-negative"
+          class="progress-error"
           :data-cy="`error-prompt-${index}`"
         >
           {{ error }}
         </div>
-        <div v-show="progressDialog.progress >= 0.999">
+        <div
+          v-show="progressDialog.progress >= 0.999"
+          class="progress-done"
+        >
           {{ $t("done") }}
         </div>
       </q-card-section>
-      <q-card-actions align="right">
+      <q-card-actions class="dialog-actions">
         <q-btn
           flat
-          :disable="progressDialog.progress < 0.999"
+          square
           :ripple="false"
+          class="dialog-btn"
+          :disable="progressDialog.progress < 0.999"
           label="OK"
           v-close-popup
           data-cy="btn-ok"
-        >
-        </q-btn>
+        />
       </q-card-actions>
     </q-card>
   </q-dialog>
@@ -48,3 +55,41 @@
 <script setup lang="ts">
 import { progressDialog } from "./dialogController";
 </script>
+<style lang="scss" scoped>
+.progress-dialog {
+  min-width: 400px;
+}
+
+.progress-bar-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.progress-bar {
+  flex: 1;
+  background: var(--q-elevated);
+  border-radius: 3px;
+}
+
+.progress-percent {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--q-text-muted);
+  min-width: 36px;
+  text-align: right;
+}
+
+.progress-error {
+  margin-top: 8px;
+  font-size: 0.8125rem;
+  color: var(--q-negative);
+}
+
+.progress-done {
+  margin-top: 8px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--q-primary);
+}
+</style>

--- a/src/components/dialogs/SuccessDialog.vue
+++ b/src/components/dialogs/SuccessDialog.vue
@@ -6,15 +6,18 @@
     no-shake
     @hide="successDialog.close()"
   >
-    <q-card class="dialog">
-      <q-card-section class="q-pt-none flex justify-center">
-        {{ successDialog.message }}
+    <q-card class="dialog success-dialog">
+      <q-card-section class="dialog-body">
+        <p class="dialog-text" style="text-align: center">
+          {{ successDialog.message }}
+        </p>
       </q-card-section>
-      <q-card-actions align="right">
+      <q-card-actions class="dialog-actions">
         <q-btn
           flat
-          dense
+          square
           :ripple="false"
+          class="dialog-btn"
           label="OK"
           @click="successDialog.close()"
           data-cy="btn-ok"
@@ -26,3 +29,8 @@
 <script setup lang="ts">
 import { successDialog } from "src/components/dialogs/dialogController";
 </script>
+<style lang="scss" scoped>
+.success-dialog {
+  min-width: 320px;
+}
+</style>

--- a/src/components/dialogs/dialogController.ts
+++ b/src/components/dialogs/dialogController.ts
@@ -162,6 +162,42 @@ function useProgressDialog() {
   };
 }
 
+/**
+ * Controller for NameDialog (used for naming projects, folders, etc.)
+ * @returns properties and controls
+ */
+function useNameDialog() {
+  const dialog = useDialog();
+  const name = ref("");
+  const title = ref("");
+  const placeholder = ref("");
+  const isDuplicate = ref(false);
+  const validateName = ref<(name: string) => boolean>(() => false);
+
+  function showWithOptions(options: {
+    title: string;
+    placeholder?: string;
+    validate?: (name: string) => boolean;
+  }) {
+    title.value = options.title;
+    placeholder.value = options.placeholder || "";
+    validateName.value = options.validate || (() => false);
+    name.value = "";
+    isDuplicate.value = false;
+    dialog.show();
+  }
+
+  return {
+    ...dialog,
+    name,
+    title,
+    placeholder,
+    isDuplicate,
+    validateName,
+    showWithOptions,
+  };
+}
+
 // use reative here so we can use properties in the composable reactively without desconstructing them
 export const importDialog = reactive(useImportDialog());
 export const deleteDialog = reactive(useDeleteDialog());
@@ -170,3 +206,4 @@ export const exportDialog = reactive(useExportDialog());
 export const errorDialog = reactive(useErrorDialog());
 export const successDialog = reactive(useSuccessDialog());
 export const progressDialog = reactive(useProgressDialog());
+export const nameDialog = reactive(useNameDialog());

--- a/src/components/layout/Stack.vue
+++ b/src/components/layout/Stack.vue
@@ -131,9 +131,8 @@ function refresh() {
 .tab-container {
   display: flex;
   flex-direction: row;
-  align-items: flex-end;
+  align-items: flex-start;
   background: var(--color-layout-header-bkgd);
   height: var(--tab-bar-height);
-  padding-top: var(--traffic-light-height);
 }
 </style>

--- a/src/components/layout/Stack.vue
+++ b/src/components/layout/Stack.vue
@@ -2,6 +2,7 @@
   <!-- the class stack is only for searching -->
   <TabContainer
     class="tab-container"
+    data-tauri-drag-region
     :enableCrossWindowDragAndDrop="enableCrossWindowDragAndDrop"
     :pages="stack.children"
     @movePage="(page: Page, id: string, pos: 'before' | 'after', fromWindow: string) => movePage(page, id, pos, fromWindow)"
@@ -125,13 +126,14 @@ function refresh() {
 .page-container {
   position: absolute;
   width: 100%;
-  height: calc(100% - 44px);
+  height: calc(100% - var(--tab-bar-height));
 }
 .tab-container {
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: flex-end;
   background: var(--color-layout-header-bkgd);
-  height: 44px;
+  height: var(--tab-bar-height);
+  padding-top: var(--traffic-light-height);
 }
 </style>

--- a/src/components/layout/Tab.vue
+++ b/src/components/layout/Tab.vue
@@ -84,7 +84,7 @@ const iconComponent = computed(() => {
   color: var(--q-text-muted);
   padding: 0 8px;
   min-width: 10rem;
-  height: 100%;
+  height: 44px;
   border-radius: 6px 6px 0 0;
   box-shadow: 0 0 0 1px var(--q-edge);
   transition: color 0.15s ease, background-color 0.15s ease;

--- a/src/components/layout/Tab.vue
+++ b/src/components/layout/Tab.vue
@@ -6,8 +6,8 @@
     <div class="row items-center">
       <component
         :is="iconComponent"
-        width="14"
-        height="14"
+        width="13"
+        height="13"
         class="q-mr-xs"
       />
       <div class="tab-label ellipsis">
@@ -21,7 +21,7 @@
       size="sm"
       class="tab-close-btn"
     >
-      <Xmark width="14" height="14" />
+      <Xmark width="12" height="12" />
     </q-btn>
     <slot name="menu"></slot>
   </div>
@@ -84,19 +84,22 @@ const iconComponent = computed(() => {
   color: var(--q-text-muted);
   padding: 0 8px;
   min-width: 10rem;
-  height: 44px;
-  border-radius: 6px 6px 0 0;
-  box-shadow: 0 0 0 1px var(--q-edge);
+  height: var(--tab-bar-height);
+  border-radius: 0;
   transition: color 0.15s ease, background-color 0.15s ease;
 
   &:hover {
     color: var(--color-layout-active-tab-fore);
     background: var(--q-hover);
+
+    .tab-close-btn {
+      opacity: 0.4;
+    }
   }
 }
 
 .tab-label {
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
   font-weight: 500;
   width: 6rem;
 }
@@ -110,7 +113,7 @@ const iconComponent = computed(() => {
 }
 
 .tab-close-btn {
-  opacity: 0.4;
+  opacity: 0;
   border-radius: 4px;
   transition: opacity 0.15s ease;
 

--- a/src/components/layout/TabContainer.vue
+++ b/src/components/layout/TabContainer.vue
@@ -87,7 +87,7 @@
     </Tab>
     <!-- trailing tab header for dropping tabs + window drag region -->
     <div
-      style="width: 100%; height: 100%"
+      style="width: 100%; height: 44px"
       data-tauri-drag-region
       @dragover="(ev) => onDragOverTabContainer(ev)"
       @dragleave="(ev) => onDragLeaveTabContainer(ev)"

--- a/src/components/layout/TabContainer.vue
+++ b/src/components/layout/TabContainer.vue
@@ -87,7 +87,7 @@
     </Tab>
     <!-- trailing tab header for dropping tabs + window drag region -->
     <div
-      style="width: 100%; height: 44px"
+      style="width: 100%; height: var(--tab-bar-height)"
       data-tauri-drag-region
       @dragover="(ev) => onDragOverTabContainer(ev)"
       @dragleave="(ev) => onDragLeaveTabContainer(ev)"

--- a/src/components/leftmenu/FolderMenu.vue
+++ b/src/components/leftmenu/FolderMenu.vue
@@ -13,7 +13,7 @@
       >
         <q-item-section>
           <i18n-t keypath="add">
-            <template #type>{{ "Markdown" }}</template>
+            <template #type>{{ $t("note") }}</template>
           </i18n-t>
         </q-item-section>
       </q-item>

--- a/src/components/leftmenu/ProjectMenu.vue
+++ b/src/components/leftmenu/ProjectMenu.vue
@@ -45,7 +45,7 @@
       >
         <q-item-section>
           <i18n-t keypath="add">
-            <template #type>Markdown</template>
+            <template #type>{{ $t("note") }}</template>
           </i18n-t>
         </q-item-section>
       </q-item>
@@ -58,6 +58,16 @@
           <i18n-t keypath="add">
             <template #type>Excalidraw</template>
           </i18n-t>
+        </q-item-section>
+      </q-item>
+
+      <q-item
+        clickable
+        v-close-popup
+        @click="onAttachFile"
+      >
+        <q-item-section>
+          {{ $t("attach-file") }}
         </q-item-section>
       </q-item>
 
@@ -107,6 +117,9 @@
 </template>
 <script setup lang="ts">
 import { NoteType } from "src/backend/database";
+import { useProjectStore } from "src/stores/projectStore";
+
+const projectStore = useProjectStore();
 
 const props = defineProps({
   projectId: { type: String, required: true },
@@ -122,4 +135,8 @@ const emit = defineEmits([
   "closeProject",
   "exportCitation",
 ]);
+
+async function onAttachFile() {
+  await projectStore.attachPDF(props.projectId);
+}
 </script>

--- a/src/components/leftmenu/ProjectNavigator.vue
+++ b/src/components/leftmenu/ProjectNavigator.vue
@@ -1,9 +1,103 @@
 <template>
-  <div class="project-nav-panel" style="height: 100%">
-    <ProjectTree />
+  <div class="project-nav-panel">
+    <div class="project-nav-header">
+      <span class="project-nav-title">{{ $t("openedProjects") }}</span>
+      <q-btn
+        class="project-nav-add-btn"
+        flat
+        dense
+        square
+        padding="xs"
+        :ripple="false"
+        @click="createProject"
+      >
+        <Plus width="14" height="14" />
+        <q-tooltip>{{ $t("add", { type: $t("project") }) }}</q-tooltip>
+      </q-btn>
+    </div>
+    <div class="project-nav-content">
+      <div
+        v-if="projectStore.openedProjects.length === 0"
+        class="project-nav-empty"
+      >
+        <span>{{ $t("empty") }}</span>
+      </div>
+      <ProjectTree v-else />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import ProjectTree from "./ProjectTree.vue";
+import { Plus } from "@iconoir/vue";
+import { useProjectStore } from "src/stores/projectStore";
+import { useProjectActions } from "src/composables/useProjectActions";
+
+const projectStore = useProjectStore();
+const { createProject: doCreateProject } = useProjectActions();
+
+function createProject() {
+  doCreateProject(
+    () => "library",
+    () => (name: string) =>
+      projectStore.projects.some(
+        (p) => p.label.toLowerCase() === name.toLowerCase()
+      )
+  );
+}
 </script>
+
+<style lang="scss" scoped>
+.project-nav-panel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.project-nav-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  flex-shrink: 0;
+}
+
+.project-nav-title {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--q-text-muted);
+}
+
+.project-nav-add-btn {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  color: var(--q-text-muted);
+  transition: color 0.15s ease, background-color 0.15s ease;
+
+  &:hover {
+    color: var(--q-reg-text);
+    background: var(--q-hover);
+  }
+}
+
+.project-nav-content {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.project-nav-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--q-text-muted);
+  font-size: 0.8125rem;
+  font-style: italic;
+  user-select: none;
+}
+</style>

--- a/src/components/leftmenu/ProjectTree.vue
+++ b/src/components/leftmenu/ProjectTree.vue
@@ -6,8 +6,7 @@
     no-connectors
     no-transition
     no-selection-unset
-    :no-nodes-label="$t('empty')"
-    :nodes="projectStore.workspaceProjects"
+    :nodes="projectStore.openedProjects"
     node-key="_id"
     selected-color="primary"
     v-model:expanded="expanded"
@@ -42,23 +41,8 @@
           @addFolder="addNode(prop.node._id, 'folder')"
           @exportCitation="showExportCitationDialog(prop.node)"
           @closeProject="closeProject(prop.node._id)"
-          @copyId="
-            () => {
-              $q.notify($t('text-copied'));
-              copyToClipboard(prop.node._id);
-            }
-          "
-          @copyAsLink="
-            () => {
-              $q.notify($t('text-copied'));
-              copyToClipboard(
-                `[${generateCiteKey(
-                  prop.node,
-                  settingStore.citeKeyRule
-                )}](sophosia://open-item/${prop.node._id})`
-              );
-            }
-          "
+          @copyId="() => copyId(prop.node._id)"
+          @copyAsLink="() => copyAsProjectLink(prop.node)"
         />
         <NoteMenu
           v-else-if="prop.node.dataType === 'note'"
@@ -66,18 +50,8 @@
           @showInNewWindow="showInNewWindow(prop.node)"
           @rename="setRenameNode(prop.node)"
           @delete="deleteNode(prop.node)"
-          @copyId="
-            () => {
-              $q.notify($t('text-copied'));
-              copyToClipboard(prop.node._id);
-            }
-          "
-          @copyAsLink="
-            () => {
-              $q.notify($t('text-copied'));
-              copyToClipboard(`[${prop.node._id}](${prop.node._id})`);
-            }
-          "
+          @copyId="() => copyId(prop.node._id)"
+          @copyAsLink="() => copyAsNoteLink(prop.node)"
         />
         <FolderMenu
           v-else
@@ -88,33 +62,7 @@
           @deleteFolder="deleteNode(prop.node)"
         />
 
-        <OpenBook
-          v-if="prop.node.dataType === 'project'"
-          width="16"
-          height="16"
-          class="q-mr-xs"
-        />
-        <Folder
-          v-else-if="prop.node.dataType === 'folder'"
-          width="16"
-          height="16"
-          class="q-mr-xs"
-        />
-        <DesignPencil
-          v-else-if="
-            prop.node.dataType === 'note' &&
-            prop.node.type === NoteType.EXCALIDRAW
-          "
-          width="16"
-          height="16"
-          class="q-mr-xs"
-        />
-        <PageIcon
-          v-else
-          width="16"
-          height="16"
-          class="q-mr-xs"
-        />
+        <NodeTypeIcon :node="prop.node" :size="16" />
         <!-- note icon has 1rem width -->
         <!-- input must have keypress.space.stop since space is default to expand row rather than space in text -->
         <div v-if="prop.node._id == renamingNodeId">
@@ -143,11 +91,7 @@
           class="ellipsis non-selectable"
           :type="prop.node.dataType"
         >
-          {{
-            prop.node.dataType === "project"
-              ? getTitle(prop.node, settingStore.showTranslatedTitle)
-              : prop.node.label
-          }}
+          {{ prop.node.label }}
           <q-tooltip> ID: {{ prop.key }} </q-tooltip>
         </div>
       </div>
@@ -155,10 +99,7 @@
   </q-tree>
 </template>
 <script setup lang="ts">
-import { invoke } from "@tauri-apps/api";
-import { exists } from "@tauri-apps/api/fs";
-import { dirname, join } from "@tauri-apps/api/path";
-import { Notify, QTree, copyToClipboard, useQuasar } from "quasar";
+import { QTree } from "quasar";
 import {
   FolderOrNote,
   Note,
@@ -167,72 +108,62 @@ import {
   PageType,
   Project,
 } from "src/backend/database";
-import { formatMetaData, generateCiteKey } from "src/backend/meta";
 import { getNotes } from "src/backend/note";
-import { getDataType, getTitle, idToPath, oldToNewId } from "src/backend/utils";
-import { exportDialog } from "src/components/dialogs/dialogController";
+import { idToPath } from "src/backend/utils";
+import { nameDialog } from "src/components/dialogs/dialogController";
+import { useProjectActions } from "src/composables/useProjectActions";
+import { useNodeActions } from "src/composables/useNodeActions";
 import { useLayoutStore } from "src/stores/layoutStore";
 import { useProjectStore } from "src/stores/projectStore";
-import { useSettingStore } from "src/stores/settingStore";
 import { metadata } from "tauri-plugin-fs-extra-api";
 import { computed, nextTick, onMounted, ref, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 import FolderMenu from "./FolderMenu.vue";
 import NoteMenu from "./NoteMenu.vue";
 import ProjectMenu from "./ProjectMenu.vue";
-import {
-  OpenBook,
-  Folder,
-  DesignPencil,
-  Page as PageIcon,
-} from "@iconoir/vue";
+import NodeTypeIcon from "src/components/shared/NodeTypeIcon.vue";
+
 const { t } = useI18n({ useScope: "global" });
 
 const layoutStore = useLayoutStore();
 const projectStore = useProjectStore();
-const settingStore = useSettingStore();
+
+const {
+  showExportCitationDialog,
+  showInExplorer,
+  showInNewWindow,
+  copyId,
+  copyAsProjectLink,
+  copyAsNoteLink,
+} = useProjectActions();
+const {
+  pathDuplicate,
+  checkDuplicate: checkDuplicateAction,
+  deleteNode: deleteNodeAction,
+  renameNote: renameNoteAction,
+  renameFolder: renameFolderAction,
+} = useNodeActions();
 
 const tree = ref<QTree | null>(null);
 const renameInput = ref<HTMLInputElement | null>(null);
 const renamingNodeId = ref("");
 const renamingNodeType = ref<"folder" | "note">("folder");
 const oldNoteName = ref("");
-const pathDuplicate = ref(false);
 const addingNode = ref(false);
 const expanded = ref<string[]>([]);
 const draggingNode = ref<Project | FolderOrNote | null>(null);
 const dragoverNode = ref<FolderOrNote | null>(null);
 const enterTime = ref(0);
-const $q = useQuasar();
 
 onMounted(async () => {
   // expand all projects
-  expanded.value = Array.from(projectStore.workspaceProjects.map((p) => p._id));
+  expanded.value = Array.from(projectStore.openedProjects.map((p) => p._id));
 });
 
 watchEffect(() => {
   showInTree(layoutStore.currentItemId);
 });
 
-/**
- * Shows the dialog to export a project's citation.
- * @param {string} project - The project to export.
- */
-async function showExportCitationDialog(project: Project) {
-  exportDialog.show();
-  exportDialog.onConfirm(async () => {
-    const format = exportDialog.format.value;
-    const options = { template: exportDialog.template.value };
-    const meta = await formatMetaData([project], format, options);
-    await copyToClipboard(meta as string);
-    $q.notify(t("text-copied"));
-  });
-}
-
-/**
- * Computed tree selection: when on the GraphPage, highlight the graph focus item;
- * otherwise highlight the current active item.
- */
 const treeSelected = computed(() => {
   if (layoutStore.currentItemId === "graph") {
     return layoutStore.graphFocusItemId || "";
@@ -240,35 +171,30 @@ const treeSelected = computed(() => {
   return layoutStore.currentItemId;
 });
 
-/**
- * Selects a project or note item and expands its tree view if necessary.
- * @param {string} nodeId - The ID of the item to select.
- */
 function selectItem(nodeId: string) {
   if (!tree.value) return;
   const node = tree.value.getNodeByKey(nodeId);
-  if ((node.children?.length as number) > 0) expanded.value.push(node._id);
-  if (node.dataType === "folder") return;
 
-  // If the Related Items tab is active, update the graph focus
-  // instead of opening the file
+  // Projects and folders toggle expand/collapse — only children (notes) open
+  if (node.dataType === "project" || node.dataType === "folder") {
+    const idx = expanded.value.indexOf(node._id);
+    if (idx > -1) expanded.value.splice(idx, 1);
+    else expanded.value.push(node._id);
+    return;
+  }
+
   if (layoutStore.currentItemId === "graph") {
     layoutStore.graphFocusItemId = node._id;
     return;
   }
 
-  layoutStore.openItem(node._id);
-}
-
-/**
- * Opens the file explorer at the location of the specified project or note.
- * @param {Project | Note} node - The project or note to show in the explorer.
- */
-async function showInExplorer(node: Project | Note) {
-  const path = idToPath(node._id);
-  await invoke("show_in_folder", {
-    path: path,
-  });
+  // PDF children open the parent project's reader
+  if (node._id.endsWith(".pdf")) {
+    const projectId = node._id.split("/")[0];
+    layoutStore.openItem(projectId);
+  } else {
+    layoutStore.openItem(node._id);
+  }
 }
 
 function showInTree(nodeId: string) {
@@ -281,66 +207,55 @@ function showInTree(nodeId: string) {
   }
 }
 
-/**
- * Show its corresponding page in a new window
- */
-function showInNewWindow(node: Project | Note) {
-  const page = { id: node._id, label: node.label } as Page;
-  const dataType = getDataType(node._id);
-  if (dataType === "note" && node._id.endsWith(".md")) {
-    page.type = PageType.NotePage;
-  } else if (dataType === "note" && node._id.endsWith(".excalidraw")) {
-    page.type = PageType.ExcalidrawPage;
-  } else {
-    page.type = PageType.ReaderPage;
-  }
-  layoutStore.showInNewWindow(page);
-}
-
-/**
- * Closes the specified project and all its associated notes.
- * @param {string} projectId - The ID of the project to close.
- */
 async function closeProject(projectId: string) {
-  // close all pages for this project
-  let project = projectStore.workspaceProjects.find((p) => p._id === projectId);
-  if (project) {
-    layoutStore.closePage(project._id);
-    const notes = await getNotes(project._id);
-    for (let node of notes) {
-      await nextTick(); // do it slowly one by one
-      layoutStore.closePage(node._id);
-    }
+  // close all open pages (project reader + notes) then remove from sidebar
+  layoutStore.closePage(projectId);
+  const notes = await getNotes(projectId);
+  for (const note of notes) {
+    layoutStore.closePage(note._id);
   }
+  projectStore.closeProject(projectId);
 }
 
-/**
- * Adds a new folder or note under the specified parent node.
- * @param {string} parentNodeId - The ID of the parent node.
- * @param {"folder" | "note"} nodeType - The type of node to add.
- * @param {NoteType} [noteType=NoteType.MARKDOWN] - The type of note to add (if nodeType is 'note').
- */
 async function addNode(
   parentNodeId: string,
   nodeType: "folder" | "note",
   noteType: NoteType = NoteType.MARKDOWN
 ) {
-  const node = await projectStore.createNode(parentNodeId, nodeType, noteType);
-  await projectStore.addNode(node);
-
-  expanded.value.push(parentNodeId);
-  addingNode.value = true;
-  // rename node
-  await nextTick(); // wait until ui updates
-  setRenameNode(node);
+  if (nodeType === "folder") {
+    nameDialog.showWithOptions({
+      title: t("new", { type: t("folder") }),
+      placeholder: t("new", { type: t("folder") }),
+      validate: (name: string) => {
+        const tree_ref = tree.value;
+        if (!tree_ref) return false;
+        const parentNode = tree_ref.getNodeByKey(parentNodeId);
+        if (!parentNode || !parentNode.children) return false;
+        return parentNode.children.some(
+          (child: FolderOrNote) =>
+            child.dataType === "folder" &&
+            child.label.toLowerCase() === name.toLowerCase()
+        );
+      },
+    });
+    nameDialog.onConfirm(async () => {
+      const node = await projectStore.createNode(parentNodeId, "folder");
+      node.label = nameDialog.name;
+      node._id = `${parentNodeId}/${nameDialog.name}`;
+      await projectStore.addNode(node);
+      expanded.value.push(parentNodeId);
+    });
+  } else {
+    const node = await projectStore.createNode(parentNodeId, nodeType, noteType);
+    await projectStore.addNode(node);
+    expanded.value.push(parentNodeId);
+    addingNode.value = true;
+    await nextTick();
+    setRenameNode(node);
+  }
 }
 
-/**
- * Sets up a node for renaming.
- * @param {FolderOrNote} node - The node to rename.
- */
 function setRenameNode(node: FolderOrNote) {
-  // set renaming note and show input
   renamingNodeId.value = node._id;
   renamingNodeType.value = node.dataType;
   oldNoteName.value = (
@@ -349,8 +264,6 @@ function setRenameNode(node: FolderOrNote) {
   pathDuplicate.value = false;
 
   setTimeout(() => {
-    // wait till input appears
-    // focus onto the input and select the text
     let input = renameInput.value;
     if (!input) return;
     input.focus();
@@ -358,97 +271,72 @@ function setRenameNode(node: FolderOrNote) {
   }, 100);
 }
 
-/**
- * Renames the specified node.
- */
 async function renameNode() {
   const node = tree.value?.getNodeByKey(renamingNodeId.value) as FolderOrNote;
-  if (!!!node) return;
+  if (!node) return;
 
   const oldNodeId = renamingNodeId.value;
-  const newNodeId = await oldToNewId(oldNodeId, node.label);
-  const newLabel = newNodeId.split("/").at(-1) as string;
-  if (pathDuplicate.value || !node.label) {
-    node.label = oldNoteName.value;
-  } else {
-    if (renamingNodeType.value === "note") {
-      // update window tab name
-      layoutStore.renamePage(oldNodeId, {
-        id: newNodeId,
-        label: newLabel,
-      } as Page);
-      await nextTick(); // wait until itemId changes in the page
-    }
-    await projectStore.renameNode(oldNodeId, newNodeId, renamingNodeType.value);
 
-    node._id = newNodeId;
-    node.label = newLabel;
+  if (renamingNodeType.value === "note") {
+    await renameNoteAction(
+      oldNodeId,
+      node.label,
+      (newNodeId, newLabel) => {
+        node._id = newNodeId;
+        node.label = newLabel;
+        if (addingNode.value) selectItem(node._id);
+        else if (layoutStore.currentItemId === oldNodeId) selectItem(newNodeId);
+      },
+      () => {
+        node.label = oldNoteName.value;
+      }
+    );
+  } else {
+    await renameFolderAction(
+      oldNodeId,
+      node.label,
+      (newFolderId, newLabel) => {
+        node._id = newFolderId;
+        node.label = newLabel;
+      },
+      () => {
+        node.label = oldNoteName.value;
+      }
+    );
   }
 
-  if (addingNode.value) selectItem(node._id); // select after adding it
-  else if (layoutStore.currentItemId === oldNodeId) selectItem(newNodeId); // select the currectly selected renaming node
-  // if renaming other nodes that are not selected, no need to select them
   addingNode.value = false;
   renamingNodeId.value = "";
   oldNoteName.value = "";
-
-  Notify.create(t("updated", { type: t("link") }));
 }
 
-/**
- * Checks for duplicate paths when renaming a node.
- * @param {Note} note - The note being renamed to check for duplicates.
- */
-async function checkDuplicate(note: Note) {
-  if (!note) return;
-  const extension = note.type === NoteType.EXCALIDRAW ? ".excalidraw" : ".md";
-  const path = await join(
-    await dirname(idToPath(note._id)),
-    note.label + extension
-  );
-
-  if ((await exists(path)) && path !== idToPath(note._id))
-    pathDuplicate.value = true;
-  else pathDuplicate.value = false;
+async function checkDuplicate(node: Note) {
+  if (!node) return;
+  await checkDuplicateAction(node, node.label);
 }
-/**
- * Deletes the specified node from the project structure.
- * @param {FolderOrNote} node - The node to delete.
- */
+
 async function deleteNode(node: FolderOrNote) {
-  if (node.dataType === "note") {
-    layoutStore.closePage(node._id);
-  } else if (node.dataType === "folder") {
-    const notes = await getNotes(node._id);
-    for (const note of notes) layoutStore.closePage(note._id);
-  }
-  await projectStore.deleteNode(node._id, node.dataType);
-  // select something else if the selectedItem is deleted
-  if (node._id === projectStore.selected[0]?._id) {
-    const projectId = node._id.split("/")[0];
-    let project = projectStore.workspaceProjects.find((p) => p._id === projectId);
-
-    if (project && project.children) {
-      if (project.children.length == 0) {
-        selectItem(project._id);
-      } else {
-        selectItem(project.children[0]._id);
+  await deleteNodeAction(node, () => {
+    if (node._id === projectStore.selected[0]?._id) {
+      const projectId = node._id.split("/")[0];
+      const project = projectStore.openedProjects.find(
+        (p) => p._id === projectId
+      );
+      if (project && project.children) {
+        if (project.children.length === 0) {
+          selectItem(project._id);
+        } else {
+          selectItem(project.children[0]._id);
+        }
       }
     }
-  }
+  });
 }
 
-/**
- * Handles the start of a drag operation.
- * @param {DragEvent} e - The drag event.
- * @param {Project | FolderOrNote} node - The node being dragged.
- */
 function onDragStart(e: DragEvent, node: Project | FolderOrNote) {
   draggingNode.value = node;
-  // need to set transfer data for some browsers to work
   e.dataTransfer?.setData("draggingNode", JSON.stringify(node));
 
-  // drag source for the layout, user can drag this and make it a page
   let pageType: PageType | undefined;
   if (node.dataType === "note" && node._id.endsWith(".md"))
     pageType = PageType.NotePage;
@@ -469,20 +357,10 @@ function onDragStart(e: DragEvent, node: Project | FolderOrNote) {
   }
 }
 
-/**
- * Handles a node being dragged over another node.
- * @param {DragEvent} e - The drag event.
- * @param {FolderOrNote} node - The node being dragged over.
- */
 function onDragOver(e: DragEvent, node: FolderOrNote) {
   if (draggingNode.value?.dataType === "project") return;
-  // enable drop on the node
   e.preventDefault();
-
-  // hightlight the dragover folder
   dragoverNode.value = node;
-
-  // expand the node if this function is called over many times
   enterTime.value++;
   if (enterTime.value > 15) {
     if (node._id in expanded.value) return;
@@ -490,26 +368,14 @@ function onDragOver(e: DragEvent, node: FolderOrNote) {
   }
 }
 
-/**
- * Resets the drag state when leaving a node.
- * @param {DragEvent} e - The drag event.
- * @param {FolderOrNote} node - The node being left.
- */
 function onDragLeave(e: DragEvent, node: FolderOrNote) {
   enterTime.value = 0;
-  dragoverNode.value = null; // dehighlight the folder
+  dragoverNode.value = null;
 }
 
-/**
- * Handles dropping a node onto another node.
- * @param {DragEvent} e - The drag event.
- * @param {Project | FolderOrNote} node - The node being dropped onto.
- */
 async function onDrop(e: DragEvent, node: Project | FolderOrNote) {
-  // record this first otherwise dragend event makes it null
   if (draggingNode.value === null || draggingNode.value == node) return;
 
-  // move the dragging file / folder
   const dragId = draggingNode.value._id;
   const dragNodeMeta = await metadata(idToPath(dragId));
   const isDragNodeDir = dragNodeMeta.isDir;
@@ -535,14 +401,13 @@ async function onDrop(e: DragEvent, node: Project | FolderOrNote) {
       label: label,
     } as Page);
   }
-  await nextTick(); // wait until the itemId is updated
+  await nextTick();
   await projectStore.renameNode(
     dragId,
     newId,
     isDragNodeDir ? "folder" : "note"
   );
 
-  // ui
   selectItem(newId);
   draggingNode.value = null;
   dragoverNode.value = null;

--- a/src/components/library/ActionBar.vue
+++ b/src/components/library/ActionBar.vue
@@ -107,34 +107,32 @@
     <q-input
       class="actionbar-input"
       outlined
+      dense
+      square
       :placeholder="$t('search', { type: $t('local') })"
       v-model="searchString"
       debounce="500"
     >
+      <template v-slot:prepend>
+        <Search width="14" height="14" style="color: var(--q-text-muted)" />
+      </template>
       <template v-slot:append>
-        <Search width="16" height="16" class="cursor-pointer" />
-        <q-btn-dropdown
-          dense
-          size="md"
-          padding="0"
-          :ripple="false"
-        >
-          <div class="text-center">Search Mode</div>
-          <div class="q-gutter-sm q-pa-sm">
-            <q-radio
-              dense
-              v-model="searchMode"
-              val="meta"
-              label="Meta"
-            />
-            <q-radio
-              dense
-              v-model="searchMode"
-              val="content"
-              label="Content"
-            />
-          </div>
-        </q-btn-dropdown>
+        <div class="search-mode-toggle">
+          <button
+            class="search-mode-btn"
+            :class="{ active: searchMode === 'meta' }"
+            @click="searchMode = 'meta'"
+          >
+            Meta
+          </button>
+          <button
+            class="search-mode-btn"
+            :class="{ active: searchMode === 'content' }"
+            @click="searchMode = 'content'"
+          >
+            Content
+          </button>
+        </div>
       </template>
     </q-input>
 
@@ -231,14 +229,48 @@ function addByID() {
 </script>
 <style lang="scss" scoped>
 .actionbar-input {
-  .q-field__control {
-    height: min(2rem, 40px);
+  max-width: 320px;
+  :deep(.q-field__control) {
+    height: 28px;
+    min-height: 28px;
   }
-  .q-field__control-container {
-    height: min(2rem, 40px);
+  :deep(.q-field__control-container) {
+    height: 28px;
   }
-  .q-field__marginal {
-    height: min(2rem, 40px);
+  :deep(.q-field__marginal) {
+    height: 28px;
+  }
+  :deep(.q-field__prepend) {
+    padding-right: 6px;
+  }
+}
+
+.search-mode-toggle {
+  display: flex;
+  gap: 2px;
+  margin-left: 4px;
+}
+
+.search-mode-btn {
+  border: none;
+  background: transparent;
+  color: var(--q-text-muted);
+  font-family: inherit;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  padding: 2px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease;
+
+  &:hover {
+    color: var(--q-reg-text);
+    background: var(--q-hover);
+  }
+
+  &.active {
+    color: var(--q-primary);
+    background: var(--q-active);
   }
 }
 </style>

--- a/src/components/library/CategoryTabs.vue
+++ b/src/components/library/CategoryTabs.vue
@@ -1,0 +1,235 @@
+<template>
+  <div class="category-tabs">
+    <div class="category-tabs-scroll">
+      <!-- Special tabs -->
+      <button
+        v-for="tab in specialTabs"
+        :key="tab.id"
+        class="category-tab"
+        :class="{ active: projectStore.selectedCategory === tab.id }"
+        @click="projectStore.selectedCategory = tab.id"
+      >
+        <component :is="tab.icon" width="14" height="14" />
+        <span>{{ $t(tab.id) }}</span>
+      </button>
+
+      <!-- User category tabs -->
+      <button
+        v-for="cat in userCategories"
+        :key="cat._id"
+        class="category-tab"
+        :class="{ active: projectStore.selectedCategory === cat._id }"
+        @click="projectStore.selectedCategory = cat._id"
+        @contextmenu.prevent="showContextMenu($event, cat)"
+      >
+        <FolderIcon width="14" height="14" />
+        <span>{{ getLabel(cat._id) }}</span>
+      </button>
+
+      <!-- Add category button -->
+      <button class="category-tab category-tab-add" @click="addCategory">
+        <Plus width="14" height="14" />
+      </button>
+    </div>
+
+    <!-- Context menu for user categories -->
+    <q-menu
+      v-model="contextMenuVisible"
+      :target="contextMenuTarget"
+      context-menu
+      class="menu"
+    >
+      <q-list dense>
+        <q-item clickable v-close-popup @click="renameCategory">
+          <q-item-section>
+            <i18n-t keypath="rename">
+              <template #type>{{ $t("category") }}</template>
+            </i18n-t>
+          </q-item-section>
+        </q-item>
+        <q-item clickable v-close-popup @click="deleteCategory">
+          <q-item-section>
+            <i18n-t keypath="delete">
+              <template #type>{{ $t("category") }}</template>
+            </i18n-t>
+          </q-item-section>
+        </q-item>
+      </q-list>
+    </q-menu>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, type Component } from "vue";
+import { CategoryNode, SpecialCategory } from "src/backend/database";
+import { useProjectStore } from "src/stores/projectStore";
+import { nameDialog } from "src/components/dialogs/dialogController";
+import { useI18n } from "vue-i18n";
+import {
+  BookStack,
+  ClockRotateRight,
+  Star,
+  Folder as FolderIcon,
+  Plus,
+} from "@iconoir/vue";
+
+const projectStore = useProjectStore();
+const { t } = useI18n({ useScope: "global" });
+
+const specialTabs: { id: string; icon: Component }[] = [
+  { id: SpecialCategory.LIBRARY, icon: BookStack },
+  { id: SpecialCategory.ADDED, icon: ClockRotateRight },
+  { id: SpecialCategory.FAVORITES, icon: Star },
+];
+
+const userCategories = ref<CategoryNode[]>([]);
+const contextMenuVisible = ref(false);
+const contextMenuTarget = ref<EventTarget | null>(null);
+const contextMenuCategory = ref<CategoryNode | null>(null);
+
+onMounted(async () => {
+  await loadCategories();
+});
+
+async function loadCategories() {
+  const tree = (await projectStore.getCategoryTree()) as CategoryNode[];
+  // The tree root is "library" node — get its children as user categories
+  if (tree.length > 0 && tree[0].children) {
+    userCategories.value = tree[0].children;
+  }
+}
+
+function getLabel(id: string): string {
+  const parts = id.split("/");
+  return parts[parts.length - 1];
+}
+
+function showContextMenu(e: MouseEvent, cat: CategoryNode) {
+  contextMenuCategory.value = cat;
+  contextMenuTarget.value = e.target;
+  contextMenuVisible.value = true;
+}
+
+function addCategory() {
+  nameDialog.showWithOptions({
+    title: t("new", { type: t("category") }),
+    placeholder: t("new", { type: t("category") }),
+    validate: (name: string) => {
+      return userCategories.value.some(
+        (c) => getLabel(c._id).toLowerCase() === name.toLowerCase()
+      );
+    },
+  });
+  nameDialog.onConfirm(async () => {
+    const newId = `library/${nameDialog.name}`;
+    // Add to UI
+    userCategories.value.push({ _id: newId, children: [] });
+    // Select the new category
+    projectStore.selectedCategory = newId;
+  });
+}
+
+async function renameCategory() {
+  const cat = contextMenuCategory.value;
+  if (!cat) return;
+  const oldLabel = getLabel(cat._id);
+
+  nameDialog.showWithOptions({
+    title: t("rename", { type: t("category") }),
+    placeholder: oldLabel,
+    validate: (name: string) => {
+      return userCategories.value.some(
+        (c) =>
+          c._id !== cat._id &&
+          getLabel(c._id).toLowerCase() === name.toLowerCase()
+      );
+    },
+  });
+  nameDialog.onConfirm(async () => {
+    const oldCategory = cat._id;
+    const parts = oldCategory.split("/");
+    parts[parts.length - 1] = nameDialog.name;
+    const newCategory = parts.join("/");
+
+    await projectStore.updateCategory(oldCategory, newCategory);
+    cat._id = newCategory;
+
+    if (projectStore.selectedCategory === oldCategory) {
+      projectStore.selectedCategory = newCategory;
+    }
+  });
+}
+
+async function deleteCategory() {
+  const cat = contextMenuCategory.value;
+  if (!cat) return;
+
+  userCategories.value = userCategories.value.filter(
+    (c) => c._id !== cat._id
+  );
+  await projectStore.deleteCategory(cat._id);
+
+  if (projectStore.selectedCategory === cat._id) {
+    projectStore.selectedCategory = SpecialCategory.LIBRARY;
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.category-tabs {
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--q-border);
+  background: var(--color-library-toolbar-bkgd);
+}
+
+.category-tabs-scroll {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.category-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--q-text-muted);
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease;
+  user-select: none;
+
+  &:hover {
+    color: var(--q-reg-text);
+    background: var(--q-hover);
+  }
+
+  &.active {
+    color: var(--q-primary);
+    background: var(--q-active);
+  }
+}
+
+.category-tab-add {
+  padding: 4px 6px;
+  color: var(--q-text-muted);
+
+  &:hover {
+    color: var(--q-primary);
+    background: var(--q-hover);
+  }
+}
+</style>

--- a/src/components/library/CategoryTabs.vue
+++ b/src/components/library/CategoryTabs.vue
@@ -9,7 +9,7 @@
         :class="{ active: projectStore.selectedCategory === tab.id }"
         @click="projectStore.selectedCategory = tab.id"
       >
-        <component :is="tab.icon" width="14" height="14" />
+        <component :is="tab.icon" width="12" height="12" />
         <span>{{ $t(tab.id) }}</span>
       </button>
 
@@ -22,13 +22,13 @@
         @click="projectStore.selectedCategory = cat._id"
         @contextmenu.prevent="showContextMenu($event, cat)"
       >
-        <FolderIcon width="14" height="14" />
+        <FolderIcon width="12" height="12" />
         <span>{{ getLabel(cat._id) }}</span>
       </button>
 
       <!-- Add category button -->
       <button class="category-tab category-tab-add" @click="addCategory">
-        <Plus width="14" height="14" />
+        <Plus width="12" height="12" />
       </button>
     </div>
 
@@ -186,7 +186,7 @@ async function deleteCategory() {
   display: flex;
   align-items: center;
   gap: 2px;
-  padding: 4px 8px;
+  padding: 2px 8px;
   overflow-x: auto;
   scrollbar-width: none;
 
@@ -198,14 +198,14 @@ async function deleteCategory() {
 .category-tab {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 4px 10px;
+  gap: 4px;
+  padding: 3px 8px;
   border: none;
-  border-radius: 6px;
+  border-radius: 4px;
   background: transparent;
   color: var(--q-text-muted);
   font-family: inherit;
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   font-weight: 500;
   white-space: nowrap;
   cursor: pointer;
@@ -224,7 +224,7 @@ async function deleteCategory() {
 }
 
 .category-tab-add {
-  padding: 4px 6px;
+  padding: 3px 5px;
   color: var(--q-text-muted);
 
   &:hover {

--- a/src/components/library/CategoryTabs.vue
+++ b/src/components/library/CategoryTabs.vue
@@ -178,15 +178,15 @@ async function deleteCategory() {
 <style lang="scss" scoped>
 .category-tabs {
   flex-shrink: 0;
+  height: var(--sub-tab-height);
   border-bottom: 1px solid var(--q-border);
   background: var(--color-library-toolbar-bkgd);
 }
 
 .category-tabs-scroll {
   display: flex;
-  align-items: center;
-  gap: 2px;
-  padding: 2px 8px;
+  align-items: stretch;
+  height: 100%;
   overflow-x: auto;
   scrollbar-width: none;
 
@@ -199,14 +199,15 @@ async function deleteCategory() {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 3px 8px;
+  padding: 0 8px;
   border: none;
-  border-radius: 4px;
+  border-radius: 0;
   background: transparent;
   color: var(--q-text-muted);
   font-family: inherit;
   font-size: 0.6875rem;
   font-weight: 500;
+  line-height: 1;
   white-space: nowrap;
   cursor: pointer;
   transition: color 0.15s ease, background-color 0.15s ease;
@@ -224,7 +225,7 @@ async function deleteCategory() {
 }
 
 .category-tab-add {
-  padding: 3px 5px;
+  padding: 0 5px;
   color: var(--q-text-muted);
 
   &:hover {

--- a/src/components/library/ProjectBrowser.vue
+++ b/src/components/library/ProjectBrowser.vue
@@ -1,59 +1,40 @@
 <template>
-  <q-splitter
-    class="project-browser-splitter"
-    :limits="[10, 30]"
-    separator-class="q-splitter-separator"
-    v-model="treeViewSize"
-  >
-    <template v-slot:before>
-      <CategoryTree
-        style="background: var(--color-library-treeview-bkgd)"
-        @exportCategory="(node: CategoryNode) => showExportReferenceDialog(node)"
-        ref="treeview"
-      />
-    </template>
-    <template v-slot:after>
-      <ActionBar
-        class="project-action-bar"
-        v-model:searchMode="searchMode"
-        v-model:searchString="searchString"
-        v-model:showReferences="projectStore.showReferences"
-        v-model:showNotebooks="projectStore.showNotebooks"
-        @addEmptyProject="addEmptyProject"
-        @addNotebook="addNotebook"
-        @addByFiles="(filePaths) => addProjectsByFiles(filePaths)"
-        @addByCollection="(collectionPath) => showImportDialog(collectionPath)"
-        @showIdentifierDialog="showIdentifierDialog()"
-        ref="actionBar"
-      />
-      <!-- actionbar height 36px, table view is 100%-36px -->
-      <ProjectTable
-        v-model:projects="projectStore.projects"
-        :searchMode="searchMode"
-        :searchString="searchString"
-        style="
-          height: calc(100% - 36px);
-          width: 100%;
-          background: var(--color-library-tableview-bkgd);
-        "
-        ref="table"
-      />
-    </template>
-  </q-splitter>
+  <div class="project-browser">
+    <CategoryTabs ref="categoryTabs" />
+    <ActionBar
+      class="project-action-bar"
+      v-model:searchMode="searchMode"
+      v-model:searchString="searchString"
+      v-model:showReferences="projectStore.showReferences"
+      v-model:showNotebooks="projectStore.showNotebooks"
+      @addEmptyProject="addEmptyProject"
+      @addNotebook="addNotebook"
+      @addByFiles="(filePaths) => addProjectsByFiles(filePaths)"
+      @addByCollection="(collectionPath) => showImportDialog(collectionPath)"
+      @showIdentifierDialog="showIdentifierDialog()"
+      ref="actionBar"
+    />
+    <ProjectTable
+      v-model:projects="projectStore.projects"
+      :searchMode="searchMode"
+      :searchString="searchString"
+      class="project-browser-table"
+      ref="table"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">
 import { nextTick, onMounted, ref, watch } from "vue";
 // types
-import { CategoryNode, Project } from "src/backend/database";
+import { Project } from "src/backend/database";
 // components
 import ActionBar from "src/components/library/ActionBar.vue";
-import CategoryTree from "src/components/library/CategoryTree.vue";
+import CategoryTabs from "src/components/library/CategoryTabs.vue";
 import ProjectTable from "src/components/library/ProjectTable.vue";
 // db
 import { basename, extname } from "@tauri-apps/api/path";
 import {
-  exportMeta,
   generateCiteKey,
   getMeta,
   getMetaFromFile,
@@ -61,29 +42,31 @@ import {
 } from "src/backend/meta";
 import { projectFileAGUD } from "src/backend/project/fileOps";
 import {
-  exportDialog,
   identifierDialog,
   importDialog,
 } from "src/components/dialogs/dialogController";
+import { useProjectActions } from "src/composables/useProjectActions";
 import { useLayoutStore } from "src/stores/layoutStore";
 import { useProjectStore } from "src/stores/projectStore";
 import { useSettingStore } from "src/stores/settingStore";
 import { extractPDFContent } from "src/backend/project";
+import { useI18n } from "vue-i18n";
 
 const projectStore = useProjectStore();
 const layoutStore = useLayoutStore();
 const settingStore = useSettingStore();
+const { t } = useI18n({ useScope: "global" });
+const { createProject } = useProjectActions();
 
 /*********************************
  * Data
  *********************************/
 // component refs
-const treeview = ref<typeof CategoryTree | null>(null);
+const categoryTabs = ref<typeof CategoryTabs | null>(null);
 
 // data
 const searchString = ref("");
 const searchMode = ref<"meta" | "content">("meta");
-const treeViewSize = ref(20);
 
 watch(
   () => [
@@ -130,21 +113,28 @@ function showImportDialog(collectionPath: string) {
   });
 }
 
-/**
- * Add an empty project to table
- */
-async function addEmptyProject() {
-  // udpate db and ui
-  const project = projectStore.createProject(projectStore.selectedCategory);
-  projectStore.addProject(project, true);
+function addEmptyProject() {
+  createProject(
+    () => projectStore.selectedCategory,
+    () => (name: string) =>
+      projectStore.projects.some(
+        (p) => p.label.toLowerCase() === name.toLowerCase()
+      )
+  );
 }
 
-/**
- * Add a notebook project
- */
-async function addNotebook() {
-  const project = projectStore.createProject(projectStore.selectedCategory);
-  projectStore.addProject(project, true);
+function addNotebook() {
+  createProject(
+    () => projectStore.selectedCategory,
+    () => (name: string) =>
+      projectStore.projects.some(
+        (p) => p.label.toLowerCase() === name.toLowerCase()
+      ),
+    {
+      title: t("new", { type: t("notebook") }),
+      placeholder: t("new", { type: t("notebook") }),
+    }
+  );
 }
 
 /**
@@ -164,7 +154,6 @@ async function addProjectsByFiles(filePaths: string[]) {
       await projectStore.updateProject(project._id, {
         path: filename,
         title: title,
-        label: title,
       } as Project);
       // do not use await since this task takes time
       getMetaFromFile(filePath).then(async (meta) => {
@@ -197,25 +186,18 @@ async function addProjectsByCollection(
   isCreateCategory: boolean
 ) {
   if (collectionPath === "") return;
-  // create category if user wants to
   if (isCreateCategory) {
-    if (!treeview.value) return;
-    let rootNode = treeview.value.getLibraryNode();
-    if (!rootNode) return;
     let categoryLabel = await basename(
       collectionPath,
       `.${await extname(collectionPath)}`
     );
-
-    let focus = true;
-    await treeview.value.addCategoryNode(rootNode, categoryLabel, focus);
+    projectStore.selectedCategory = `library/${categoryLabel}`;
   }
 
-  await nextTick(); //wait until ui actions settled
+  await nextTick();
 
   let metas = await importMeta(collectionPath);
   for (let meta of metas) {
-    // add a new project to db and update it with meta
     let project = projectStore.createProject(projectStore.selectedCategory);
     await projectStore.addProject(project, true);
     (meta as Project)._id = generateCiteKey(meta, settingStore.projectIdRule);
@@ -237,34 +219,25 @@ async function addProjectByIdentifier(identifier: string) {
   await projectStore.updateProject(project._id, meta as Project);
 }
 
-/**
- * Open export dialog for citation export
- * @param {CategoryNode} node - The category which needs to be exported
- */
-function showExportReferenceDialog(node: CategoryNode) {
-  exportDialog.show();
-  exportDialog.onConfirm(async () => {
-    let options = undefined;
-    const format = exportDialog.format.value;
-    if (format === "bibliography")
-      options = { template: exportDialog.template.value };
-    await exportCategory(format, node, options);
-  });
-}
-/**********************************************************
- * CategoryTree
- **********************************************************/
-
-/**
- * Exports a category as a collection of references in a specified format.
- * @param {string} format - The citation.js supported format.
- * @param {object} options - Extra export options.
- */
-async function exportCategory(
-  format: string,
-  categoryNode: CategoryNode,
-  options?: { format?: string; template?: string }
-) {
-  await exportMeta(categoryNode, format, options);
-}
 </script>
+<style lang="scss" scoped>
+.project-browser {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.project-action-bar {
+  flex-shrink: 0;
+  padding: 0 8px;
+  height: 36px;
+}
+
+.project-browser-table {
+  flex: 1;
+  width: 100%;
+  background: var(--color-library-tableview-bkgd);
+  overflow: hidden;
+}
+</style>

--- a/src/components/library/ProjectTable.vue
+++ b/src/components/library/ProjectTable.vue
@@ -38,7 +38,7 @@
           :props="props"
           style="padding: 0"
         >
-          <span class="text-subtitle1 text-bold">{{ col.label }}</span>
+          {{ col.label }}
         </q-th>
       </q-tr>
     </template>

--- a/src/components/library/TableItemRow.vue
+++ b/src/components/library/TableItemRow.vue
@@ -16,16 +16,7 @@
         class="row items-center"
         data-cy="content"
       >
-        <DesignPencil
-          v-if="item.type === NoteType.EXCALIDRAW"
-          width="14"
-          height="14"
-        />
-        <PageIcon
-          v-else
-          width="14"
-          height="14"
-        />
+        <NodeTypeIcon :node="item" :size="14" />
         <div
           v-if="renaming"
           class="row"
@@ -50,7 +41,7 @@
         </div>
         <div
           v-else
-          style="font-size: 1rem"
+          style="font-size: 0.875rem"
           class="q-ml-xs"
         >
           {{ label }}
@@ -62,14 +53,10 @@
       colspan="100%"
     >
       <div class="row items-center">
-        <OpenBook
-          width="14"
-          height="14"
-          class="q-mr-xs"
-        />
+        <NodeTypeIcon :node="item" :size="14" />
         <div
           class="col"
-          style="font-size: 1rem"
+          style="font-size: 0.875rem"
         >
           {{ label }}
         </div>
@@ -80,14 +67,10 @@
       colspan="100%"
     >
       <div class="row items-center">
-        <Folder
-          width="14"
-          height="14"
-          class="q-mr-xs"
-        />
+        <NodeTypeIcon :node="item" :size="14" />
         <div
           class="col"
-          style="font-size: 1rem"
+          style="font-size: 0.875rem"
         >
           {{ label }}
         </div>
@@ -102,34 +85,24 @@
       @setRenaming="setRenaming"
       @deleteItem="deleteItem"
       @renamePDF="renamePDF"
-      @copyId="
-        () => {
-          $q.notify($t('text-copied'));
-          copyToClipboard(item._id);
-        }
-      "
-      @copyAsLink="
-        () => {
-          $q.notify($t('text-copied'));
-          copyToClipboard(`[${item._id}](${item._id})`);
-        }
-      "
+      @copyId="() => copyId(item._id)"
+      @copyAsLink="() => copyAsNoteLink(item)"
     />
   </q-tr>
 </template>
 <script setup lang="ts">
-import { Note, NoteType, Page, PageType, Project } from "src/backend/database";
-import { PropType, Ref, inject, nextTick, ref, watchEffect } from "vue";
+import { Note, FolderOrNote, Project } from "src/backend/database";
+import { PropType, Ref, inject, ref, watchEffect } from "vue";
 import { invoke } from "@tauri-apps/api";
-import { exists } from "@tauri-apps/api/fs";
-import { basename, dirname, join } from "@tauri-apps/api/path";
-import { copyToClipboard } from "quasar";
-import { idToPath, oldToNewId } from "src/backend/utils";
+import { basename } from "@tauri-apps/api/path";
+import { idToPath } from "src/backend/utils";
+import { useProjectActions } from "src/composables/useProjectActions";
+import { useNodeActions } from "src/composables/useNodeActions";
 import { useLayoutStore } from "src/stores/layoutStore";
 import { useProjectStore } from "src/stores/projectStore";
 import { useSettingStore } from "src/stores/settingStore";
 import TableItemMenu from "./TableItemMenu.vue";
-import { DesignPencil, Folder, OpenBook, Page as PageIcon } from "@iconoir/vue";
+import NodeTypeIcon from "src/components/shared/NodeTypeIcon.vue";
 
 const props = defineProps({
   item: { type: Object as PropType<Project | Note>, required: true },
@@ -137,13 +110,23 @@ const props = defineProps({
 const layoutStore = useLayoutStore();
 const projectStore = useProjectStore();
 const settingStore = useSettingStore();
+const {
+  showInNewWindow: showInNewWindowAction,
+  copyId,
+  copyAsNoteLink,
+} = useProjectActions();
+const {
+  pathDuplicate,
+  checkDuplicate: checkDuplicateAction,
+  deleteNode,
+  renameNote: doRenameNote,
+} = useNodeActions();
 
 const renaming = ref(false);
 const renameInput = ref<HTMLInputElement | null>(null);
 const label = ref("");
 const renamingNoteId = inject("renamingNoteId") as Ref<string>;
 const oldNoteName = ref("");
-const pathDuplicate = ref(false);
 
 watchEffect(async () => {
   const path = props.item.path || idToPath(props.item._id);
@@ -161,14 +144,7 @@ async function showInExplorer() {
 }
 
 function showInNewWindow() {
-  const type = props.item._id.endsWith(".md")
-    ? PageType.NotePage
-    : PageType.ExcalidrawPage;
-  layoutStore.showInNewWindow({
-    id: props.item._id,
-    type: type,
-    label: props.item.label,
-  });
+  showInNewWindowAction(props.item);
 }
 
 function clickItem() {
@@ -192,28 +168,24 @@ function setRenaming() {
 }
 
 async function renameNote() {
-  let note = props.item as Note;
-  if (pathDuplicate.value) {
-    note.label = oldNoteName.value;
-    label.value = oldNoteName.value;
-  } else {
-    const oldNoteId = note._id;
-    const newNoteId = await oldToNewId(oldNoteId, label.value);
-    const newLabel = await basename(newNoteId);
-    layoutStore.renamePage(oldNoteId, {
-      id: newNoteId,
-      label: newLabel,
-    } as Page);
-    await nextTick(); // wait until itemId changes in the page
-    await projectStore.renameNode(oldNoteId, newNoteId, "note");
-  }
-  renaming.value = false;
-  renamingNoteId.value = "";
-  pathDuplicate.value = false;
+  await doRenameNote(
+    props.item._id,
+    label.value,
+    () => {
+      renaming.value = false;
+      renamingNoteId.value = "";
+    },
+    () => {
+      (props.item as Note).label = oldNoteName.value;
+      label.value = oldNoteName.value;
+      renaming.value = false;
+      renamingNoteId.value = "";
+    }
+  );
 }
 
 async function deleteItem() {
-  await projectStore.deleteNode(props.item._id, "note");
+  await deleteNode(props.item as FolderOrNote);
 }
 
 async function renamePDF() {
@@ -221,15 +193,6 @@ async function renamePDF() {
 }
 
 async function checkDuplicate() {
-  const extension =
-    props.item.type === NoteType.EXCALIDRAW ? ".excalidraw" : ".md";
-  const path = await join(
-    await dirname(idToPath(props.item._id)),
-    label.value.endsWith(extension) ? label.value : label.value + extension
-  );
-
-  if ((await exists(path)) && path !== idToPath(props.item._id))
-    pathDuplicate.value = true;
-  else pathDuplicate.value = false;
+  await checkDuplicateAction(props.item as Note, label.value);
 }
 </script>

--- a/src/components/library/TableProjectMenu.vue
+++ b/src/components/library/TableProjectMenu.vue
@@ -169,18 +169,15 @@ import {
   Meta,
   Note,
   NoteType,
-  PageType,
   Project,
   SpecialCategory,
-  db,
 } from "src/backend/database";
 import { Ref, inject, nextTick, ref } from "vue";
 // db
-import { invoke } from "@tauri-apps/api";
-import { join } from "@tauri-apps/api/path";
 import { copyToClipboard } from "quasar";
 import { generateCiteKey, getMeta } from "src/backend/meta";
 import { getProject } from "src/backend/project";
+import { useProjectActions } from "src/composables/useProjectActions";
 import { useLayoutStore } from "src/stores/layoutStore";
 import { useProjectStore } from "src/stores/projectStore";
 import { useSettingStore } from "src/stores/settingStore";
@@ -194,6 +191,10 @@ import {
 const projectStore = useProjectStore();
 const layoutStore = useLayoutStore();
 const settingStore = useSettingStore();
+const {
+  showInExplorer: showInExplorerAction,
+  showInNewWindow: showInNewWindowAction,
+} = useProjectActions();
 const props = defineProps({
   projectId: { type: String, required: true },
 });
@@ -250,25 +251,15 @@ async function openProject() {
 import { useQuasar } from "quasar";
 const $q = useQuasar();
 
-/**
- * Opens the file explorer and navigates to the location of the selected project(s).
- */
 async function showInExplorer() {
-  for (let project of projectStore.selected) {
-    let path = await join(db.config.storagePath, project._id);
-    await invoke("show_in_folder", {
-      path: path,
-    });
+  for (const project of projectStore.selected) {
+    await showInExplorerAction(project as Project);
   }
 }
 
 function showInNewWindow() {
   const project = projectStore.selected[0];
-  layoutStore.showInNewWindow({
-    id: project._id,
-    type: PageType.ReaderPage,
-    label: project.label,
-  });
+  showInNewWindowAction(project as Project);
 }
 
 /**

--- a/src/components/library/TableProjectRow.vue
+++ b/src/components/library/TableProjectRow.vue
@@ -37,14 +37,14 @@
     >
       <div
         v-if="col.name === 'author'"
-        style="font-size: 1rem"
+        style="font-size: 0.875rem"
         class="ellipsis"
       >
         {{ shortAuthorString(col.value as Author[]) }}
       </div>
       <div
         v-else
-        style="font-size: 1rem; min-width: 20vw; max-width: 50vw"
+        style="font-size: 0.875rem; min-width: 20vw; max-width: 50vw"
         class="ellipsis"
       >
         {{
@@ -65,21 +65,17 @@
 </template>
 
 <script setup lang="ts">
-import { copyToClipboard, useQuasar } from "quasar";
 import { Author, Project } from "src/backend/database";
-import { formatMetaData } from "src/backend/meta";
 import { getTitle } from "src/backend/utils";
+import { useProjectActions } from "src/composables/useProjectActions";
 import { useSettingStore } from "src/stores/settingStore";
 import { PropType, ref } from "vue";
-import { useI18n } from "vue-i18n";
-import { exportDialog } from "../dialogs/dialogController";
 import TableProjectMenu from "./TableProjectMenu.vue";
 import { NavArrowDown, NavArrowRight } from "@iconoir/vue";
 
-const { t } = useI18n({ useScope: "global" });
+const { showExportCitationDialog } = useProjectActions();
 const settingStore = useSettingStore();
 const menu = ref<InstanceType<typeof TableProjectMenu>>();
-const $q = useQuasar();
 
 const props = defineProps({
   tableProps: {
@@ -98,17 +94,6 @@ const emit = defineEmits(["expandRow", "setFavorite"]);
 
 function expandRow(isExpand: boolean) {
   emit("expandRow", isExpand);
-}
-
-async function showExportCitationDialog(project: Project) {
-  exportDialog.show();
-  exportDialog.onConfirm(async () => {
-    const format = exportDialog.format.value;
-    const options = { template: exportDialog.template.value };
-    const meta = await formatMetaData([project], format, options);
-    await copyToClipboard(meta as string);
-    $q.notify(t("text-copied"));
-  });
 }
 
 function shortAuthorString(authors: Author[]) {

--- a/src/components/library/TableSearchRow.vue
+++ b/src/components/library/TableSearchRow.vue
@@ -3,7 +3,7 @@
     <q-td colspan="100%">
       <div
         :style="`width: ${width}px;`"
-        style="font-size: 0.9rem"
+        style="font-size: 0.8125rem"
         class="q-px-lg ellipsis text-grey"
         v-html="text"
         data-cy="text"

--- a/src/components/settings/AboutTab.vue
+++ b/src/components/settings/AboutTab.vue
@@ -1,46 +1,38 @@
 <template>
-  <div class="q-pb-md">
-    <q-card
-      flat
-      class="q-my-md card"
+  <div class="about-section">
+    <div class="about-header">
+      <q-icon
+        name="img:icons/logo.svg"
+        size="lg"
+        alt="logo"
+      />
+      <div class="about-title">{{ `${$t("sophosia")} ${version}` }}</div>
+      <q-btn
+        v-if="!isUpdateAvailable"
+        class="btn q-ml-md"
+        unelevated
+        :ripple="false"
+        no-caps
+        :label="$t('check-for-updates')"
+        @click="checkForUpdate"
+      />
+      <q-btn
+        v-else
+        unelevated
+        class="btn q-ml-md"
+        :ripple="false"
+        no-caps
+        :label="$t('download-updates')"
+        @click="downloadUpdate"
+        :disable="disabled"
+      />
+    </div>
+    <div
+      v-if="updateMsg"
+      class="about-update-msg"
     >
-      <q-card-section>
-        <div class="row items-center justify-between">
-          <div class="text-h6 row items-center">
-            <q-icon
-              name="img:icons/logo.svg"
-              size="lg"
-              alt="logo"
-            />
-            <div class="q-ml-sm">{{ `${$t("sophosia")} ${version}` }}</div>
-          </div>
-          <div>
-            <q-btn
-              v-if="!isUpdateAvailable"
-              class="btn"
-              unelevated
-              :ripple="false"
-              no-caps
-              :label="$t('check-for-updates')"
-              @click="checkForUpdate"
-            />
-            <q-btn
-              v-else
-              unelevated
-              class="btn"
-              :ripple="false"
-              no-caps
-              :label="$t('download-updates')"
-              @click="downloadUpdate"
-              :disable="disabled"
-            />
-          </div>
-        </div>
-      </q-card-section>
-      <q-card-section class="q-pt-none">
-        <div style="white-space: pre-wrap">{{ updateMsg }}</div>
-      </q-card-section>
-    </q-card>
+      {{ updateMsg }}
+    </div>
   </div>
 </template>
 <script setup lang="ts">
@@ -93,3 +85,28 @@ async function downloadUpdate() {
   await installUpdate();
 }
 </script>
+<style lang="scss" scoped>
+.about-section {
+  max-width: 600px;
+}
+
+.about-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.about-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--q-reg-text);
+}
+
+.about-update-msg {
+  margin-top: 12px;
+  font-size: 0.8125rem;
+  color: var(--q-text-muted);
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+</style>

--- a/src/components/settings/CustomRuleModifier.vue
+++ b/src/components/settings/CustomRuleModifier.vue
@@ -1,46 +1,42 @@
 <template>
-  <q-card
-    flat
-    class="q-my-md card"
-  >
-    <q-card-section>
-      <div class="row">
-        <div class="text-h6">
-          {{
-            ruleType === "citeKey"
-              ? $t("citation-key")
-              : ruleType === "pdfRename"
-              ? $t("rename", { type: "PDF" })
-              : `${$t("project")} ID`
-          }}
-        </div>
-        <q-btn
-          class="btn q-ml-sm"
-          no-caps
-          :ripple="false"
-          :label="
-            $t('update', {
-              type:
-                ruleType === 'citeKey'
-                  ? $t('citation-key')
-                  : ruleType === 'pdfRename'
-                  ? $t('rename', { type: 'PDF' })
-                  : `${$t('project')} ID`,
-            })
-          "
-          @click="$emit('bulkUpdate')"
-        ></q-btn>
-      </div>
-    </q-card-section>
-    <q-card-section class="q-pt-none">
-      <div>
+  <div class="rule-section">
+    <div class="rule-header">
+      <span class="rule-title">
+        {{
+          ruleType === "citeKey"
+            ? $t("citation-key")
+            : ruleType === "pdfRename"
+            ? $t("rename", { type: "PDF" })
+            : `${$t("project")} ID`
+        }}
+      </span>
+      <q-btn
+        class="btn q-ml-sm"
+        no-caps
+        :ripple="false"
+        :label="
+          $t('update', {
+            type:
+              ruleType === 'citeKey'
+                ? $t('citation-key')
+                : ruleType === 'pdfRename'
+                ? $t('rename', { type: 'PDF' })
+                : `${$t('project')} ID`,
+          })
+        "
+        @click="$emit('bulkUpdate')"
+      />
+    </div>
+    <div class="rule-body">
+      <div class="rule-info">
         <div>{{ $t("custom-citekey-rule") }}</div>
-        <div>{{ citeKeyKeywords.join(", ") }}</div>
+        <div class="rule-keywords">{{ citeKeyKeywords.join(", ") }}</div>
       </div>
-      <div class="text-bold q-mt-sm">{{ $t("preview") }}</div>
+      <div class="rule-preview-label">{{ $t("preview") }}</div>
       <div
         v-for="(meta, index) in exampleMetas"
         :key="index"
+        class="rule-preview"
       >
         <div class="row">
           <div class="q-pr-xs">{{ $t("project") }}:</div>
@@ -59,14 +55,15 @@
       </div>
 
       <q-input
+        class="rule-input"
         outlined
         dense
         v-model="customRule"
         :error-message="$t('contains-invalid-keywords-or-connectors')"
         :error="!isRuleValid"
       />
-    </q-card-section>
-  </q-card>
+    </div>
+  </div>
 </template>
 <script setup lang="ts">
 import { Meta } from "src/backend/database";
@@ -120,3 +117,51 @@ onMounted(async () => {
   })) as string;
 });
 </script>
+<style lang="scss" scoped>
+.rule-section {
+  padding: 16px 0;
+  border-bottom: 1px solid var(--q-border);
+}
+
+.rule-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.rule-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--q-reg-text);
+}
+
+.rule-body {
+  font-size: 0.8125rem;
+  color: var(--q-text-muted);
+}
+
+.rule-keywords {
+  font-size: 0.75rem;
+  color: var(--q-text-muted);
+  margin-top: 2px;
+}
+
+.rule-preview-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--q-reg-text);
+  margin-top: 8px;
+  margin-bottom: 4px;
+}
+
+.rule-preview {
+  font-size: 0.8125rem;
+  color: var(--q-text-muted);
+  margin-bottom: 4px;
+}
+
+.rule-input {
+  max-width: 320px;
+  margin-top: 8px;
+}
+</style>

--- a/src/components/settings/GeneralTab.vue
+++ b/src/components/settings/GeneralTab.vue
@@ -1,83 +1,58 @@
 <template>
-  <div class="q-pb-md">
-    <q-card
-      flat
-      class="q-my-md card"
-    >
-      <q-card-section>
-        <div class="text-h6">{{ $t("theme") }}</div>
-      </q-card-section>
-      <q-card-section class="q-pt-none">
-        <q-select
-          class="selector"
-          dense
-          outlined
-          :options="themeOptions"
-          :display-value="theme[0].toUpperCase() + theme.slice(1)"
-          v-model="theme"
-        >
-          <template v-slot:option="scope">
-            <q-item v-bind="scope.itemProps">
-              <q-item-section>
-                <q-item-label>
-                  {{ scope.opt[0].toUpperCase() + scope.opt.slice(1) }}
-                </q-item-label>
-              </q-item-section>
-            </q-item>
-          </template>
-        </q-select>
-      </q-card-section>
-    </q-card>
+  <div class="settings-sections">
+    <div class="settings-section">
+      <div class="section-title">{{ $t("theme") }}</div>
+      <q-select
+        class="section-input"
+        dense
+        outlined
+        :options="themeOptions"
+        :display-value="theme[0].toUpperCase() + theme.slice(1)"
+        v-model="theme"
+      >
+        <template v-slot:option="scope">
+          <q-item v-bind="scope.itemProps">
+            <q-item-section>
+              <q-item-label>
+                {{ scope.opt[0].toUpperCase() + scope.opt.slice(1) }}
+              </q-item-label>
+            </q-item-section>
+          </q-item>
+        </template>
+      </q-select>
+    </div>
 
-    <q-card
-      flat
-      class="q-my-md card"
-    >
-      <q-card-section>
-        <div class="text-h6">{{ $t("font") }}</div>
-      </q-card-section>
-      <q-card-section class="q-pt-none">
-        <div style="font-size: 1rem">
-          {{ $t("font-size-fontsize-px", [fontSize]) }}
-        </div>
-        <q-slider
-          class="col q-pl-md"
-          :min="14"
-          :max="25"
-          markers
-          snap
-          v-model="fontSize"
-        ></q-slider>
-      </q-card-section>
-    </q-card>
+    <div class="settings-section">
+      <div class="section-title">{{ $t("font") }}</div>
+      <div class="section-text">
+        {{ $t("font-size-fontsize-px", [fontSize]) }}
+      </div>
+      <q-slider
+        :min="14"
+        :max="25"
+        markers
+        snap
+        v-model="fontSize"
+      />
+    </div>
 
-    <q-card
-      flat
-      class="q-my-md card"
-    >
-      <q-card-section>
-        <div class="text-h6">{{ $t("language") }}</div>
-      </q-card-section>
-      <q-card-section class="q-pt-none">
-        <q-select
-          dense
-          outlined
-          v-model="language"
-          :options="languageOptions"
-        />
-      </q-card-section>
-    </q-card>
+    <div class="settings-section">
+      <div class="section-title">{{ $t("language") }}</div>
+      <q-select
+        class="section-input"
+        dense
+        outlined
+        v-model="language"
+        :options="languageOptions"
+      />
+    </div>
 
-    <q-card
-      flat
-      class="q-my-md card"
-    >
-      <q-card-section>
-        <div class="text-h6">{{ $t("pdftranslate") }}</div>
-      </q-card-section>
-      <q-card-section class="q-pt-none">
-        {{ $t("language") }}
+    <div class="settings-section">
+      <div class="section-title">{{ $t("pdftranslate") }}</div>
+      <div class="section-field">
+        <label class="field-label">{{ $t("language") }}</label>
         <q-select
+          class="section-input"
           dense
           outlined
           map-options
@@ -85,9 +60,11 @@
           v-model="settingStore.pdfTranslateLanguage"
           :options="pdfTranslateOptions"
         />
-
-        {{ $t("engine") }}
+      </div>
+      <div class="section-field">
+        <label class="field-label">{{ $t("engine") }}</label>
         <q-select
+          class="section-input"
           dense
           outlined
           map-options
@@ -95,38 +72,34 @@
           v-model="settingStore.pdfTranslateEngine"
           :options="pdfTranslateEngineOptions"
         />
-
-        API Key
+      </div>
+      <div class="section-field">
+        <label class="field-label">API Key</label>
         <q-input
+          class="section-input"
           v-model="settingStore.pdfTranslateApiKey"
           :disable="settingStore.pdfTranslateEngine === 'google'"
           dense
           outlined
         />
-      </q-card-section>
-    </q-card>
+      </div>
+    </div>
 
-    <q-card
-      flat
-      class="q-my-md card"
-    >
-      <q-card-section>
-        <div class="text-h6">{{ $t("display-translated-title") }}</div>
-        <div>
-          {{ $t("display-translated-title-info") }}
-        </div>
-      </q-card-section>
-      <q-card-section class="q-pt-none">
-        <q-select
-          dense
-          outlined
-          emit-value
-          map-options
-          v-model="settingStore.showTranslatedTitle"
-          :options="titleTranslateOptions"
-        />
-      </q-card-section>
-    </q-card>
+    <div class="settings-section">
+      <div class="section-title">{{ $t("display-translated-title") }}</div>
+      <div class="section-text">
+        {{ $t("display-translated-title-info") }}
+      </div>
+      <q-select
+        class="section-input"
+        dense
+        outlined
+        emit-value
+        map-options
+        v-model="settingStore.showTranslatedTitle"
+        :options="titleTranslateOptions"
+      />
+    </div>
 
     <CustomRuleModifier
       v-model:rule="settingStore.citeKeyRule"
@@ -296,3 +269,48 @@ async function onIndexFiles() {
   await db.setConfig({ lastScanTime: Date.now() } as Config);
 }
 </script>
+<style lang="scss" scoped>
+.settings-sections {
+  max-width: 600px;
+}
+
+.settings-section {
+  padding: 16px 0;
+  border-bottom: 1px solid var(--q-border);
+
+  &:first-child {
+    padding-top: 0;
+  }
+}
+
+.section-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--q-reg-text);
+  margin-bottom: 8px;
+}
+
+.section-text {
+  font-size: 0.8125rem;
+  color: var(--q-text-muted);
+  margin-bottom: 8px;
+}
+
+.section-input {
+  max-width: 320px;
+}
+
+.section-field {
+  margin-bottom: 8px;
+}
+
+.field-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--q-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+}
+</style>

--- a/src/components/settings/IndexFileCard.vue
+++ b/src/components/settings/IndexFileCard.vue
@@ -1,26 +1,43 @@
 <template>
-  <q-card
-    flat
-    class="q-my-md card"
-  >
-    <q-card-section>
-      <div class="row">
-        <div class="text-h6">{{ $t("index-files") }}</div>
-        <q-btn
-          class="btn q-ml-sm"
-          no-caps
-          :ripple="false"
-          :label="$t('index-files')"
-          @click="$emit('indexFiles')"
-        ></q-btn>
-      </div>
-    </q-card-section>
-
-    <q-card-section class="q-pt-none">
+  <div class="index-section">
+    <div class="index-header">
+      <span class="index-title">{{ $t("index-files") }}</span>
+      <q-btn
+        class="btn q-ml-sm"
+        no-caps
+        :ripple="false"
+        :label="$t('index-files')"
+        @click="$emit('indexFiles')"
+      />
+    </div>
+    <div class="index-info">
       {{ $t("index-files-info") }}
-    </q-card-section>
-  </q-card>
+    </div>
+  </div>
 </template>
 <script setup lang="ts">
 const emit = defineEmits(["indexFiles"]);
 </script>
+<style lang="scss" scoped>
+.index-section {
+  padding: 16px 0;
+}
+
+.index-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.index-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--q-reg-text);
+}
+
+.index-info {
+  font-size: 0.8125rem;
+  color: var(--q-text-muted);
+  line-height: 1.5;
+}
+</style>

--- a/src/components/settings/SettingsMenu.vue
+++ b/src/components/settings/SettingsMenu.vue
@@ -9,7 +9,7 @@
           :class="{ active: activeTab === tab.id }"
           @click="activeTab = tab.id"
         >
-          <component :is="tab.icon" width="14" height="14" />
+          <component :is="tab.icon" width="12" height="12" />
           <span>{{ $t(tab.label) }}</span>
         </button>
       </div>
@@ -54,7 +54,7 @@ const activeTab = ref("general");
   display: flex;
   align-items: center;
   gap: 2px;
-  padding: 4px 8px;
+  padding: 2px 8px;
   overflow-x: auto;
   scrollbar-width: none;
 
@@ -66,14 +66,14 @@ const activeTab = ref("general");
 .settings-tab {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 4px 10px;
+  gap: 4px;
+  padding: 3px 8px;
   border: none;
-  border-radius: 6px;
+  border-radius: 4px;
   background: transparent;
   color: var(--q-text-muted);
   font-family: inherit;
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   font-weight: 500;
   white-space: nowrap;
   cursor: pointer;

--- a/src/components/settings/SettingsMenu.vue
+++ b/src/components/settings/SettingsMenu.vue
@@ -1,85 +1,99 @@
 <template>
-  <q-splitter
-    v-model="leftMenuSize"
-    :limits="[10, 30]"
-    class="fit"
-    separator-class="q-splitter-separator"
-  >
-    <template v-slot:before>
-      <div class="settings-panel">
-        <q-tabs
-          v-model="tab"
-          vertical
-          no-caps
-          stretch
-          inline-label
-          align="left"
-          indicator-color="transparent"
+  <div class="settings-page">
+    <div class="settings-tabs">
+      <div class="settings-tabs-scroll">
+        <button
+          v-for="tab in tabs"
+          :key="tab.id"
+          class="settings-tab"
+          :class="{ active: activeTab === tab.id }"
+          @click="activeTab = tab.id"
         >
-          <q-tab
-            name="general"
-            :ripple="false"
-          >
-            <Settings width="20" height="20" />
-            <span class="q-ml-xs settings-tab-label">
-              {{ $t("general") }}
-            </span>
-          </q-tab>
-          <q-tab
-            name="plugin"
-            :ripple="false"
-          >
-            <Puzzle width="20" height="20" />
-            <span class="q-ml-xs settings-tab-label">
-              {{ $t("plugins") }}
-            </span>
-          </q-tab>
-          <q-tab
-            name="about"
-            :ripple="false"
-          >
-            <InfoCircle width="20" height="20" />
-            <span class="q-ml-xs settings-tab-label">
-              {{ $t("about") }}
-            </span>
-          </q-tab>
-        </q-tabs>
+          <component :is="tab.icon" width="14" height="14" />
+          <span>{{ $t(tab.label) }}</span>
+        </button>
       </div>
-    </template>
-
-    <template v-slot:after>
-      <div class="fit row">
-        <q-tab-panels
-          v-model="tab"
-          vertical
-          class="settings fit"
-        >
-          <q-tab-panel name="general">
-            <GeneralTab />
-          </q-tab-panel>
-          <q-tab-panel name="plugin">
-            <PluginTab />
-          </q-tab-panel>
-          <q-tab-panel name="about">
-            <AboutTab />
-          </q-tab-panel>
-        </q-tab-panels>
-      </div>
-    </template>
-  </q-splitter>
+    </div>
+    <div class="settings-content">
+      <GeneralTab v-if="activeTab === 'general'" />
+      <PluginTab v-else-if="activeTab === 'plugin'" />
+      <AboutTab v-else-if="activeTab === 'about'" />
+    </div>
+  </div>
 </template>
 <script setup lang="ts">
+import { ref, type Component } from "vue";
+import { Settings, Puzzle, InfoCircle } from "@iconoir/vue";
 import AboutTab from "src/components/settings/AboutTab.vue";
 import GeneralTab from "src/components/settings/GeneralTab.vue";
 import PluginTab from "src/components/settings/plugin/PluginTab.vue";
-import { ref } from "vue";
-import { Settings, Puzzle, InfoCircle } from "@iconoir/vue";
 
-const leftMenuSize = ref(20);
-const tab = ref("general");
+const tabs: { id: string; label: string; icon: Component }[] = [
+  { id: "general", label: "general", icon: Settings },
+  { id: "plugin", label: "plugins", icon: Puzzle },
+  { id: "about", label: "about", icon: InfoCircle },
+];
+
+const activeTab = ref("general");
 </script>
-<style scoped lang="scss">
-.settings-tab-label {
-  font-size: 0.875rem;
+<style lang="scss" scoped>
+.settings-page {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.settings-tabs {
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--q-border);
+  background: var(--q-surface);
+}
+
+.settings-tabs-scroll {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.settings-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--q-text-muted);
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease;
+  user-select: none;
+
+  &:hover {
+    color: var(--q-reg-text);
+    background: var(--q-hover);
+  }
+
+  &.active {
+    color: var(--q-primary);
+    background: var(--q-active);
+  }
+}
+
+.settings-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 24px;
 }
 </style>

--- a/src/components/settings/SettingsMenu.vue
+++ b/src/components/settings/SettingsMenu.vue
@@ -46,15 +46,15 @@ const activeTab = ref("general");
 
 .settings-tabs {
   flex-shrink: 0;
+  height: var(--sub-tab-height);
   border-bottom: 1px solid var(--q-border);
   background: var(--q-surface);
 }
 
 .settings-tabs-scroll {
   display: flex;
-  align-items: center;
-  gap: 2px;
-  padding: 2px 8px;
+  align-items: stretch;
+  height: 100%;
   overflow-x: auto;
   scrollbar-width: none;
 
@@ -67,14 +67,15 @@ const activeTab = ref("general");
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 3px 8px;
+  padding: 0 8px;
   border: none;
-  border-radius: 4px;
+  border-radius: 0;
   background: transparent;
   color: var(--q-text-muted);
   font-family: inherit;
   font-size: 0.6875rem;
   font-weight: 500;
+  line-height: 1;
   white-space: nowrap;
   cursor: pointer;
   transition: color 0.15s ease, background-color 0.15s ease;

--- a/src/components/shared/NodeTypeIcon.vue
+++ b/src/components/shared/NodeTypeIcon.vue
@@ -1,0 +1,43 @@
+<template>
+  <OpenBook
+    v-if="node.dataType === 'project'"
+    :width="size"
+    :height="size"
+    class="q-mr-xs"
+  />
+  <Folder
+    v-else-if="node.dataType === 'folder'"
+    :width="size"
+    :height="size"
+    class="q-mr-xs"
+  />
+  <DesignPencil
+    v-else-if="node.dataType === 'note' && node.type === NoteType.EXCALIDRAW"
+    :width="size"
+    :height="size"
+    class="q-mr-xs"
+  />
+  <PageIcon
+    v-else
+    :width="size"
+    :height="size"
+    class="q-mr-xs"
+  />
+</template>
+<script setup lang="ts">
+import { FolderOrNote, NoteType, Project } from "src/backend/database";
+import {
+  OpenBook,
+  Folder,
+  DesignPencil,
+  Page as PageIcon,
+} from "@iconoir/vue";
+
+withDefaults(
+  defineProps<{
+    node: Project | FolderOrNote;
+    size?: number;
+  }>(),
+  { size: 16 }
+);
+</script>

--- a/src/composables/useNodeActions.ts
+++ b/src/composables/useNodeActions.ts
@@ -1,0 +1,100 @@
+import { exists } from "@tauri-apps/api/fs";
+import { dirname, join } from "@tauri-apps/api/path";
+import { Notify } from "quasar";
+import {
+  FolderOrNote,
+  Note,
+  NoteType,
+  Page,
+} from "src/backend/database";
+import { getNotes } from "src/backend/note";
+import { idToPath, oldToNewId } from "src/backend/utils";
+import { useLayoutStore } from "src/stores/layoutStore";
+import { useProjectStore } from "src/stores/projectStore";
+import { nextTick, ref } from "vue";
+import { useI18n } from "vue-i18n";
+
+export function useNodeActions() {
+  const { t } = useI18n({ useScope: "global" });
+  const layoutStore = useLayoutStore();
+  const projectStore = useProjectStore();
+  const pathDuplicate = ref(false);
+
+  async function checkDuplicate(node: Note, currentLabel: string) {
+    const extension =
+      node.type === NoteType.EXCALIDRAW ? ".excalidraw" : ".md";
+    const labelWithExt = currentLabel.endsWith(extension)
+      ? currentLabel
+      : currentLabel + extension;
+    const path = await join(
+      await dirname(idToPath(node._id)),
+      labelWithExt
+    );
+
+    pathDuplicate.value =
+      (await exists(path)) && path !== idToPath(node._id);
+  }
+
+  async function deleteNode(
+    node: FolderOrNote,
+    onAfterDelete?: () => void
+  ) {
+    if (node.dataType === "note") {
+      layoutStore.closePage(node._id);
+    } else if (node.dataType === "folder") {
+      const notes = await getNotes(node._id);
+      for (const note of notes) {
+        layoutStore.closePage(note._id);
+      }
+    }
+    await projectStore.deleteNode(node._id, node.dataType);
+    onAfterDelete?.();
+  }
+
+  async function renameNote(
+    oldNoteId: string,
+    newLabel: string,
+    onSuccess: (newNoteId: string, newLabel: string) => void,
+    onCancel: () => void
+  ) {
+    if (pathDuplicate.value || !newLabel) {
+      onCancel();
+      return;
+    }
+    const newNoteId = await oldToNewId(oldNoteId, newLabel);
+    const finalLabel = newNoteId.split("/").at(-1) as string;
+    layoutStore.renamePage(oldNoteId, {
+      id: newNoteId,
+      label: finalLabel,
+    } as Page);
+    await nextTick();
+    await projectStore.renameNode(oldNoteId, newNoteId, "note");
+    onSuccess(newNoteId, finalLabel);
+    Notify.create(t("updated", { type: t("link") }));
+  }
+
+  async function renameFolder(
+    oldFolderId: string,
+    newLabel: string,
+    onSuccess: (newFolderId: string, newLabel: string) => void,
+    onCancel: () => void
+  ) {
+    if (pathDuplicate.value || !newLabel) {
+      onCancel();
+      return;
+    }
+    const newFolderId = await oldToNewId(oldFolderId, newLabel);
+    const finalLabel = newFolderId.split("/").at(-1) as string;
+    await projectStore.renameNode(oldFolderId, newFolderId, "folder");
+    onSuccess(newFolderId, finalLabel);
+    Notify.create(t("updated", { type: t("link") }));
+  }
+
+  return {
+    pathDuplicate,
+    checkDuplicate,
+    deleteNode,
+    renameNote,
+    renameFolder,
+  };
+}

--- a/src/composables/useProjectActions.ts
+++ b/src/composables/useProjectActions.ts
@@ -1,0 +1,103 @@
+import { invoke } from "@tauri-apps/api";
+import { copyToClipboard, useQuasar } from "quasar";
+import {
+  FolderOrNote,
+  Page,
+  PageType,
+  Project,
+} from "src/backend/database";
+import { formatMetaData, generateCiteKey } from "src/backend/meta";
+import { getDataType, idToPath } from "src/backend/utils";
+import {
+  exportDialog,
+  nameDialog,
+} from "src/components/dialogs/dialogController";
+import { useLayoutStore } from "src/stores/layoutStore";
+import { useProjectStore } from "src/stores/projectStore";
+import { useSettingStore } from "src/stores/settingStore";
+import { useI18n } from "vue-i18n";
+
+export function useProjectActions() {
+  const $q = useQuasar();
+  const { t } = useI18n({ useScope: "global" });
+  const layoutStore = useLayoutStore();
+  const projectStore = useProjectStore();
+  const settingStore = useSettingStore();
+
+  async function showExportCitationDialog(project: Project) {
+    exportDialog.show();
+    exportDialog.onConfirm(async () => {
+      const format = exportDialog.format.value;
+      const options = { template: exportDialog.template.value };
+      const meta = await formatMetaData([project], format, options);
+      await copyToClipboard(meta as string);
+      $q.notify(t("text-copied"));
+    });
+  }
+
+  async function showInExplorer(node: Project | FolderOrNote) {
+    const path = idToPath(node._id);
+    await invoke("show_in_folder", { path });
+  }
+
+  function showInNewWindow(node: Project | FolderOrNote) {
+    const page = { id: node._id, label: node.label } as Page;
+    const dataType = getDataType(node._id);
+    if (dataType === "note" && node._id.endsWith(".md")) {
+      page.type = PageType.NotePage;
+    } else if (dataType === "note" && node._id.endsWith(".excalidraw")) {
+      page.type = PageType.ExcalidrawPage;
+    } else {
+      page.type = PageType.ReaderPage;
+    }
+    layoutStore.showInNewWindow(page);
+  }
+
+  function copyId(id: string) {
+    copyToClipboard(id);
+    $q.notify(t("text-copied"));
+  }
+
+  function copyAsProjectLink(node: Project) {
+    const citeKey = generateCiteKey(node, settingStore.citeKeyRule);
+    copyToClipboard(
+      `[${citeKey}](sophosia://open-item/${node._id})`
+    );
+    $q.notify(t("text-copied"));
+  }
+
+  function copyAsNoteLink(node: FolderOrNote) {
+    copyToClipboard(`[${node._id}](${node._id})`);
+    $q.notify(t("text-copied"));
+  }
+
+  function createProject(
+    getCategory: () => string,
+    getDuplicateCheck: () => (name: string) => boolean,
+    options?: { title?: string; placeholder?: string }
+  ) {
+    const title = options?.title || t("new", { type: t("project") });
+    const placeholder = options?.placeholder || title;
+    nameDialog.showWithOptions({
+      title,
+      placeholder,
+      validate: getDuplicateCheck(),
+    });
+    nameDialog.onConfirm(async () => {
+      const project = projectStore.createProject(getCategory());
+      project.label = nameDialog.name;
+      project.title = nameDialog.name;
+      projectStore.addProject(project, true);
+    });
+  }
+
+  return {
+    showExportCitationDialog,
+    showInExplorer,
+    showInNewWindow,
+    copyId,
+    copyAsProjectLink,
+    copyAsNoteLink,
+    createProject,
+  };
+}

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -363,22 +363,71 @@ a {
 }
 
 // ----------------------------------------------------------
-// Dialogs
+// Dialogs: Shared Classes
 // ----------------------------------------------------------
 .export-dialog {
-  min-width: 300px;
+  min-width: 380px;
 }
 
-.progess-dialog {
-  width: 50vw;
+.progress-dialog {
+  min-width: 400px;
 }
 
 .import-dialog {
-  min-width: 500px;
+  min-width: 420px;
 }
 
 .identifier-dialog {
-  min-width: 500px;
+  min-width: 420px;
+}
+
+.dialog-header {
+  padding: 20px 24px 0;
+}
+
+.dialog-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--q-reg-text);
+  letter-spacing: -0.01em;
+}
+
+.dialog-body {
+  padding: 16px 24px;
+}
+
+.dialog-text {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--q-text-muted);
+  line-height: 1.5;
+}
+
+.dialog-actions {
+  padding: 8px 16px 16px;
+  justify-content: flex-end;
+}
+
+.dialog-btn {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  padding: 4px 16px;
+  border-radius: 6px;
+  color: var(--q-text-muted);
+  transition: color 0.15s ease, background-color 0.15s ease;
+
+  &:hover {
+    color: var(--q-reg-text);
+    background: var(--q-hover);
+  }
+}
+
+.dialog-btn--danger {
+  color: var(--q-negative);
+
+  &:hover {
+    background: rgba(248, 113, 113, 0.1);
+  }
 }
 
 // ----------------------------------------------------------

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -94,17 +94,17 @@ body {
 :root {
   --sidebar-width: 270px;
   --traffic-light-height: 0px;
-  --tab-bar-height: 44px;
+  --tab-bar-height: 34px;
+  --sub-tab-height: 34px;
+  --header-total-height: 68px; // tab-bar + sub-tab
 }
 
 body[data-platform="Darwin"] {
   --traffic-light-height: 38px;
-  --tab-bar-height: calc(44px + 38px);
 }
 
 body[data-platform="Darwin"][data-fullscreen="true"] {
   --traffic-light-height: 0px;
-  --tab-bar-height: 44px;
 }
 
 // ----------------------------------------------------------

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -94,14 +94,17 @@ body {
 :root {
   --sidebar-width: 270px;
   --traffic-light-height: 0px;
+  --tab-bar-height: 44px;
 }
 
 body[data-platform="Darwin"] {
   --traffic-light-height: 38px;
+  --tab-bar-height: calc(44px + 38px);
 }
 
 body[data-platform="Darwin"][data-fullscreen="true"] {
   --traffic-light-height: 0px;
+  --tab-bar-height: 44px;
 }
 
 // ----------------------------------------------------------

--- a/src/layouts/UnifiedSidebar.vue
+++ b/src/layouts/UnifiedSidebar.vue
@@ -160,7 +160,7 @@ defineEmits(["openPage"]);
   align-items: center;
   gap: 2px;
   padding: 0 6px;
-  height: 44px;
+  height: calc(var(--header-total-height) - var(--traffic-light-height));
   flex-shrink: 0;
   border-bottom: 1px solid var(--q-border);
 }
@@ -170,8 +170,8 @@ defineEmits(["openPage"]);
 }
 
 .sidebar-icon-btn {
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   border-radius: 6px;
   color: var(--q-text-muted);
   transition: color 0.15s ease, background-color 0.15s ease;

--- a/src/layouts/UnifiedSidebar.vue
+++ b/src/layouts/UnifiedSidebar.vue
@@ -159,7 +159,8 @@ defineEmits(["openPage"]);
   flex-direction: row;
   align-items: center;
   gap: 2px;
-  padding: 4px 6px;
+  padding: 0 6px;
+  height: 44px;
   flex-shrink: 0;
   border-bottom: 1px solid var(--q-border);
 }

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -41,64 +41,70 @@ import { useLayoutStore } from "./layoutStore";
 import { generateCiteKey, getMetaFromFile } from "src/backend/meta";
 import { useSettingStore } from "./settingStore";
 
+/**
+ * If a project has an attached PDF, inject a synthetic child node
+ * so the sidebar tree shows the PDF under the project.
+ */
+async function injectPDFChild(project: Project) {
+  if (!project.path) return;
+  const pdfLabel = await basename(project.path);
+  if (project.children?.some((c) => c.label === pdfLabel)) return;
+  if (!project.children) project.children = [];
+  project.children.unshift({
+    _id: `${project._id}/${pdfLabel}`,
+    label: pdfLabel,
+    dataType: "note",
+  } as FolderOrNote);
+}
+
+/**
+ * Fetch a project from DB with PDF + notes, inject PDF child, and sort.
+ */
+async function fetchAndPrepareProject(projectId: string): Promise<Project> {
+  const project = (await getProject(projectId, {
+    includePDF: true,
+    includeNotes: true,
+  })) as Project;
+  await injectPDFChild(project);
+  sortTree(project);
+  return project;
+}
+
 export const useProjectStore = defineStore("projectStore", {
   state: () => ({
-    initialized: false, // is project loaded
+    initialized: false,
     showReferences: true,
     showNotebooks: true,
-    selected: [] as (Project | Note)[], // projectIds selected by checkbox
-    projects: [] as Project[], // array of projects
-    openedProjects: [] as Project[], // array of opened projects
-    workspaceProjects: [] as Project[], // all projects in workspace (for sidebar tree)
+    selected: [] as (Project | Note)[],
+    projects: [] as Project[], // library view (filtered by category)
+    openedProjects: [] as Project[], // sidebar + tabs (only explicitly opened)
 
-    updatedProject: {} as Project, // for updating window tab name
-    selectedCategory: SpecialCategory.LIBRARY.toString(), // selected category in library page
-    // fire after a rename of note/folder, batchReplaceLink will change contents of markdowns containing the link to old note/folder
+    updatedProject: {} as Project,
+    selectedCategory: SpecialCategory.LIBRARY.toString(),
     isNotesUpdated: false,
   }),
 
   actions: {
-    /**
-     * Given the appState, initialize the store
-     * Will load the openedProjects and the projects corresponding to the selectedCategory
-     * @param {AppState} state
-     */
     async loadState(state: AppState) {
       if (this.initialized) return;
       this.selectedCategory = state.selectedCategory;
       await this.loadOpenedProjects(state.openedProjectIds);
-      await this.loadWorkspaceProjects();
       await this.loadProjects(state.selectedCategory);
       this.initialized = true;
     },
 
-    /**
-     * Output the data needs to be saved
-     * @returns {AppState} The data needs to be saved
-     */
     saveState(): AppState {
-      const projectIds = this.openedProjects.map((project) => project._id);
-      const uniqueIds = new Set(projectIds);
+      const uniqueIds = new Set(this.openedProjects.map((p) => p._id));
       return {
         openedProjectIds: [...uniqueIds],
         selectedCategory: this.selectedCategory,
       } as AppState;
     },
 
-    /**
-     * Retrieves a project from the store based on its projectId.
-     * @param projectId - The unique identifier of the project.
-     * @returns The project object if found, otherwise undefined.
-     */
     getProject(projectId: string) {
       return this.projects.find((project) => project._id === projectId);
     },
 
-    /**
-     * Loads a project from the database including its PDF and notes, if any.
-     * @param projectId - The unique identifier of the project to load.
-     * @returns A project object with detailed information.
-     */
     async getProjectFromDB(projectId: string) {
       return await getProject(projectId, {
         includePDF: true,
@@ -106,133 +112,61 @@ export const useProjectStore = defineStore("projectStore", {
       });
     },
 
-    /**
-     * Loads projects identified by their IDs into the openedProjects array.
-     * @param openedProjectIds - An array or set of project IDs to be loaded.
-     */
     async loadOpenedProjects(openedProjectIds: string[]) {
       const openedProjects = [];
-      const uniqueIds = new Set(openedProjectIds);
-      for (let projectId of uniqueIds) {
-        const project = (await this.getProjectFromDB(projectId)) as Project;
-        sortTree(project); // sort notes by alphabet
-        openedProjects.push(project);
+      for (const projectId of new Set(openedProjectIds)) {
+        openedProjects.push(await fetchAndPrepareProject(projectId));
       }
-      // only change the this.openedProjects in the final step
-      // this is to avoid the confusing of proxy object update
       this.openedProjects = openedProjects;
     },
 
-    /**
-     * Loads all projects in the workspace for the sidebar tree.
-     */
-    async loadWorkspaceProjects() {
-      const projects = await getProjects(SpecialCategory.LIBRARY, {
-        includePDF: true,
-        includeNotes: true,
-      });
-      for (const project of projects) {
-        sortTree(project);
-      }
-      this.workspaceProjects = projects;
-    },
-
-    /**
-     * Opens a project by loading its details from the database and adding it to the openedProjects array if not already present.
-     * @param projectId - The unique identifier of the project to open.
-     */
     async openProject(projectId: string) {
-      console.log("opened", projectId);
-      let project = (await this.getProjectFromDB(projectId)) as Project;
-      if (!this.openedProjects.map((p) => p._id).includes(project._id))
-        this.openedProjects.push(project);
-      // ensure project is in workspace sidebar
-      if (!this.workspaceProjects.find((p) => p._id === project._id)) {
-        sortTree(project);
-        this.workspaceProjects.push(project);
-      }
+      if (this.openedProjects.some((p) => p._id === projectId)) return;
+      const project = await fetchAndPrepareProject(projectId);
+      this.openedProjects.push(project);
     },
 
-    /**
-     * Creates a new project in a specified folder.
-     * @param category - The unique identifier of the category where the project is to be created.
-     * @returns A new project object.
-     */
+    closeProject(projectId: string) {
+      const idx = this.openedProjects.findIndex((p) => p._id === projectId);
+      if (idx > -1) this.openedProjects.splice(idx, 1);
+    },
+
     createProject(category: string) {
       return createProject(category);
     },
 
-    /**
-     * Adds a project to the projects array in the store. Optionally saves the project to the database.
-     * @param project - The project object to add.
-     * @param saveToDB - Boolean indicating whether to save the project to the database.
-     */
     async addProject(project: Project, saveToDB?: boolean) {
       if (saveToDB) project = (await addProject(project)) as Project;
       if (!this.getProject(project._id)) this.projects.push(project);
-      // keep workspace sidebar in sync
-      if (!this.workspaceProjects.find((p) => p._id === project._id))
-        this.workspaceProjects.push(project);
     },
 
-    /**
-     * Updates the details of a project both in the projects and openedProjects arrays.
-     * @param projectId - The unique identifier of the project to update.
-     * @param props - The new properties to be updated in the project.
-     */
     async updateProject(projectId: string, props: Project) {
-      let newProject = (await updateProject(projectId, props)) as Project;
-      this._updateProjectUI(projectId, newProject);
+      const newProject = (await updateProject(projectId, props)) as Project;
+      await this._updateProjectUI(projectId, newProject);
     },
 
-    _updateProjectUI(projectId: string, newProject: Project) {
-      let projectInList = this.projects.find((p) => p._id === projectId);
-      let projectInOpened = this.openedProjects.find(
-        (p) => p._id === projectId
-      );
-      let projectInWorkspace = this.workspaceProjects.find(
-        (p) => p._id === projectId
-      );
+    async _updateProjectUI(projectId: string, newProject: Project) {
+      await injectPDFChild(newProject);
 
-      // project exists in list
-      if (projectInList) Object.assign(projectInList, newProject);
-      // project exists in opened project lists
-      if (projectInOpened) Object.assign(projectInOpened, newProject);
-      // project exists in workspace sidebar
-      if (projectInWorkspace) Object.assign(projectInWorkspace, newProject);
+      for (const list of [this.projects, this.openedProjects]) {
+        const existing = list.find((p) => p._id === projectId);
+        if (existing) Object.assign(existing, newProject);
+      }
 
       this.updatedProject = newProject;
     },
 
-    /**
-     * Deletes a project from the projects array and optionally from the database.
-     * @param projectId - The unique identifier of the project to delete.
-     * @param deleteFromDB - Boolean indicating whether to delete the project from the database.
-     * @param folderId - Optional folder ID if the project is within a folder.
-     */
     async deleteProject(
       projectId: string,
       deleteFromDB: boolean,
       folderId?: string
     ) {
-      let ind = this.projects.findIndex((p) => p._id === projectId);
-      if (ind > -1) {
-        // update ui
-        this.projects.splice(ind, 1);
-        this.selected = this.selected.filter((p) => p._id === projectId);
-        // remove from workspace sidebar
-        const wsInd = this.workspaceProjects.findIndex((p) => p._id === projectId);
-        if (wsInd > -1) this.workspaceProjects.splice(wsInd, 1);
-        // update db
-        await deleteProject(projectId, deleteFromDB, folderId);
-      }
+      this.projects = this.projects.filter((p) => p._id !== projectId);
+      this.selected = this.selected.filter((p) => p._id !== projectId);
+      this.closeProject(projectId);
+      if (deleteFromDB) await deleteProject(projectId, deleteFromDB, folderId);
     },
 
-    /**
-     * Loads all projects under a specific folder from the database.
-     * Filters out necessary items based on showReferences and showNotebooks
-     * @param category - The unique identifier of the folder whose projects are to be loaded.
-     */
     async loadProjects(category: string) {
       this.projects = await getProjects(category, {
         includePDF: true,
@@ -248,14 +182,8 @@ export const useProjectStore = defineStore("projectStore", {
       });
     },
 
-    /**
-     * Renames the PDF file associated with a project.
-     * @param projectId - The unique identifier of the project whose PDF is to be renamed.
-     */
     async renamePDF(projectId: string, renameRule: string) {
-      // update db
       const newPath = await projectFileAGUD.renamePDF(projectId, renameRule);
-      // update ui
       let project = this.getProject(projectId);
       if (!project) return;
       Object.assign(project, { path: newPath });
@@ -268,17 +196,11 @@ export const useProjectStore = defineStore("projectStore", {
       });
     },
 
-    /**
-     * Attaches a PDF to a project.
-     * @param projectId - The unique identifier of the project to which the PDF will be attached.
-     */
     async attachPDF(projectId: string) {
-      // update db
       const filename = await projectFileAGUD.attachPDF(projectId);
       const filePath = idToPath(`${projectId}/${filename}`);
       const settingStore = useSettingStore();
       getMetaFromFile(filePath).then(async (meta) => {
-        // FIXME: when meta is undefined, we can trigger the extract pdf content
         let newProjectId = projectId;
         if (meta) {
           meta["citation-key"] = generateCiteKey(
@@ -295,27 +217,17 @@ export const useProjectStore = defineStore("projectStore", {
         await extractPDFContent((await projectFileAGUD.getPDF(newProjectId))!);
       });
 
-      // update ui
-      if (filename)
-        await this.updateProject(projectId, { path: filename } as Project);
+      if (filename) {
+        const project = await fetchAndPrepareProject(projectId);
+        project.path = filename;
+        await this._updateProjectUI(projectId, project);
+      }
     },
 
-    /**
-     * Retrieves a note from the database based on its unique identifier.
-     * @param noteId - The unique identifier of the note to retrieve.
-     * @returns The requested note object.
-     */
     async getNoteFromDB(noteId: string) {
       return await getNote(noteId);
     },
 
-    /**
-     * Creates a new folder or note under a specific parent node.
-     * @param parentNodeId - The unique identifier of the parent node.
-     * @param nodeType - Type of the node to create ('folder' or 'note').
-     * @param noteType - The type of note to create, if the node is a note.
-     * @returns The newly created node object.
-     */
     async createNode(
       parentNodeId: string,
       nodeType: "folder" | "note",
@@ -325,89 +237,44 @@ export const useProjectStore = defineStore("projectStore", {
       else return await createNote(parentNodeId, noteType);
     },
 
-    /**
-     * Adds a folder or note to the store and database.
-     * @param node - The node object (folder or note) to add.
-     */
     async addNode(node: FolderOrNote) {
-      // update db
       if (node.dataType === "folder") await addFolder(node);
       else await addNote(node as Note);
-      // update ui
       const projectId = node._id.split("/")[0];
-      const project = (await this.getProjectFromDB(projectId)) as Project;
-      sortTree(project);
-      this._updateProjectUI(projectId, project);
+      const project = await fetchAndPrepareProject(projectId);
+      await this._updateProjectUI(projectId, project);
     },
 
-    /**
-     * Renames a folder or note both in the store and the database.
-     * @param oldNodeId - The original unique identifier of the node.
-     * @param newNodeId - The new unique identifier for the node.
-     * @param nodeType - The type of the node ('folder' or 'note').
-     */
     async renameNode(
       oldNodeId: string,
       newNodeId: string,
       nodeType: "folder" | "note"
     ) {
-      // update db
       if (nodeType === "folder") await renameFolder(oldNodeId, newNodeId);
       else await renameNote(oldNodeId, newNodeId);
-      // update ui
-      const oldProjectId = oldNodeId.split("/")[0];
-      const newProjectId = newNodeId.split("/")[0];
-      for (const projectId of new Set([oldProjectId, newProjectId])) {
-        let project = (await this.getProjectFromDB(projectId)) as Project;
-        sortTree(project);
-        this._updateProjectUI(projectId, project);
+      for (const projectId of new Set([
+        oldNodeId.split("/")[0],
+        newNodeId.split("/")[0],
+      ])) {
+        const project = await fetchAndPrepareProject(projectId);
+        await this._updateProjectUI(projectId, project);
       }
     },
 
-    /**
-     * Deletes a folder or note from the store and database.
-     * @param nodeId - The unique identifier of the node to delete.
-     * @param nodeType - The type of the node ('folder' or 'note').
-     */
     async deleteNode(nodeId: string, nodeType: "folder" | "note") {
       if (nodeType === "folder") await deleteFolder(nodeId);
       else await deleteNote(nodeId);
-      // update ui
       const projectId = nodeId.split("/")[0];
-      let project = (await this.getProjectFromDB(projectId)) as Project;
-      sortTree(project);
-      this._updateProjectUI(projectId, project);
+      const project = await fetchAndPrepareProject(projectId);
+      await this._updateProjectUI(projectId, project);
     },
 
-    /**
-     * Get category tree
-     *
-     * @returns {Promise<CategoryNode[]>}
-     */
     async getCategoryTree(): Promise<CategoryNode[]> {
       return await getCategoryTree();
     },
 
-    /**
-     * Update category and the corresponding projects
-     *
-     * @param {string} oldCategory
-     * @param {string} newCategory
-     *
-     * @example
-     * To rename a category (and its subcategories)
-     * updateCategory(oldCategory, newCategory)
-     *
-     * @example
-     * To move a category into another category
-     * move library/category1 into library/category2
-     * updateCategory("library/category1", "library/category2/category1")
-     * duplicate must be check before using this function
-     */
     async updateCategory(oldCategory: string, newCategory: string) {
-      // updte db
       await updateCategory(oldCategory, newCategory);
-      // update UI
       for (const project of this.projects) {
         project.categories = project.categories.map((category) =>
           category.replace(oldCategory, newCategory)
@@ -415,15 +282,8 @@ export const useProjectStore = defineStore("projectStore", {
       }
     },
 
-    /**
-     * Delete a category and its subcategories
-     *
-     * @param {string} category
-     */
     async deleteCategory(category: string) {
-      // update db
       await deleteCategory(category);
-      // update UI
       for (const project of this.projects) {
         project.categories = project.categories.filter(
           (cat) => !cat.startsWith(category)


### PR DESCRIPTION
## Summary

Comprehensive refactoring to unify sidebar and library UI behavior, fix PDF attachment sync issues, simplify the project store, and apply consistent design system typography across all dialogs and settings pages.

- Extracted project/node actions into composables (`useProjectActions`, `useNodeActions`) and created shared `NodeTypeIcon` component to eliminate code duplication between sidebar and library
- Fixed critical bugs: PDF attachments now appear in sidebar tree, `deleteItem` closes open tabs, `showInNewWindow` uses correct PageType detection
- Simplified `projectStore` by removing redundant `workspaceProjects` array and consolidating into `openedProjects` with `fetchAndPrepareProject()` helper
- Updated all 8 dialog components with shared CSS classes matching the new design system (header, title, body, actions, buttons)
- Normalized typography across library tables (1rem → 0.875rem) and settings (flat sections with 0.75rem-0.9375rem scale instead of Quasar classes)
- Converted settings page from vertical sidebar tabs to horizontal tabs across top to match CategoryTabs pattern

## Test plan

- Run `yarn test:unit:ci` — all 31 tests pass
- Test sidebar: expand/collapse projects, click child items to open, verify PDFs appear and open correctly
- Test library: verify project actions (delete, rename, copy, export citation) work from all contexts
- Test dialogs: verify all 8 dialogs render with correct spacing, typography, and colors
- Test settings: verify horizontal tab navigation, form inputs, and preview panes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)