### PR TITLE
Scale tabs to 40px and customize EmbedPDF toolbar

### DIFF
--- a/src/components/layout/Tab.vue
+++ b/src/components/layout/Tab.vue
@@ -6,8 +6,8 @@
     <div class="row items-center">
       <component
         :is="iconComponent"
-        width="13"
-        height="13"
+        width="15"
+        height="15"
         class="q-mr-xs"
       />
       <div class="tab-label ellipsis">
@@ -21,7 +21,7 @@
       size="sm"
       class="tab-close-btn"
     >
-      <Xmark width="12" height="12" />
+      <Xmark width="14" height="14" />
     </q-btn>
     <slot name="menu"></slot>
   </div>
@@ -99,7 +99,7 @@ const iconComponent = computed(() => {
 }
 
 .tab-label {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   font-weight: 500;
   width: 6rem;
 }

--- a/src/components/leftmenu/ProjectNavigator.vue
+++ b/src/components/leftmenu/ProjectNavigator.vue
@@ -64,7 +64,7 @@ function createProject() {
 }
 
 .project-nav-title {
-  font-size: 0.6875rem;
+  font-size: 0.875rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;

--- a/src/components/library/CategoryTabs.vue
+++ b/src/components/library/CategoryTabs.vue
@@ -9,7 +9,7 @@
         :class="{ active: projectStore.selectedCategory === tab.id }"
         @click="projectStore.selectedCategory = tab.id"
       >
-        <component :is="tab.icon" width="12" height="12" />
+        <component :is="tab.icon" width="14" height="14" />
         <span>{{ $t(tab.id) }}</span>
       </button>
 
@@ -22,13 +22,13 @@
         @click="projectStore.selectedCategory = cat._id"
         @contextmenu.prevent="showContextMenu($event, cat)"
       >
-        <FolderIcon width="12" height="12" />
+        <FolderIcon width="14" height="14" />
         <span>{{ getLabel(cat._id) }}</span>
       </button>
 
       <!-- Add category button -->
       <button class="category-tab category-tab-add" @click="addCategory">
-        <Plus width="12" height="12" />
+        <Plus width="14" height="14" />
       </button>
     </div>
 
@@ -205,7 +205,7 @@ async function deleteCategory() {
   background: transparent;
   color: var(--q-text-muted);
   font-family: inherit;
-  font-size: 0.6875rem;
+  font-size: 0.875rem;
   font-weight: 500;
   line-height: 1;
   white-space: nowrap;

--- a/src/components/pdfreader/PDFReader.vue
+++ b/src/components/pdfreader/PDFReader.vue
@@ -19,6 +19,7 @@
     </div>
     <PDFViewer
       v-else-if="viewerConfig"
+      ref="pdfViewerRef"
       :key="sourceUrl"
       class="embedpdf-viewer"
       :config="viewerConfig"
@@ -57,9 +58,42 @@ const loading = ref(false);
 const sourceUrl = ref("");
 const errorMessage = ref("");
 const viewerRegistry = ref<PluginRegistry | null>(null);
+const pdfViewerRef = ref<InstanceType<typeof PDFViewer> | null>(null);
 
 let clearViewerSubscriptions: Array<() => void> = [];
 let importingLegacy = false;
+
+function injectCompactToolbarStyles() {
+  const el = pdfViewerRef.value?.$el;
+  if (!el) return;
+  const container = el.querySelector("embedpdf-container");
+  if (!container?.shadowRoot) return;
+  const style = document.createElement("style");
+  style.textContent = `
+    [data-epdf-i="main-toolbar"] {
+      height: 40px;
+      padding-block: 0;
+      box-sizing: border-box;
+    }
+    [data-epdf-i="main-toolbar"] button {
+      height: 28px;
+      min-height: 28px;
+      min-width: 28px;
+    }
+    [data-epdf-i="main-toolbar"] .h-\\[32px\\] {
+      height: 28px;
+    }
+    [data-epdf-i="document-menu-button"],
+    [data-epdf-i="sidebar-button"],
+    [data-epdf-i="page-settings-button"],
+    [data-epdf-i="overflow-left-action-menu-button"],
+    [data-epdf-i="divider-1"],
+    [data-epdf-i="divider-2"] {
+      display: none !important;
+    }
+  `;
+  container.shadowRoot.appendChild(style);
+}
 
 type TrackedAnnotation = { object: PdfAnnotationObject };
 type AnnotationStateLike = { byUid: Record<string, TrackedAnnotation> };
@@ -104,7 +138,42 @@ const viewerConfig = computed(() => {
   return {
     src: sourceUrl.value,
     theme: {
-      preference: "system",
+      preference: "dark" as const,
+      dark: {
+        accent: {
+          primary: "#818cf8",
+          primaryHover: "#6366f1",
+          primaryActive: "#4f46e5",
+          primaryLight: "rgba(129, 140, 248, 0.18)",
+          primaryForeground: "#ffffff",
+        },
+        background: {
+          app: "#0f1117",
+          surface: "#1a1b23",
+          surfaceAlt: "#1a1b23",
+          elevated: "#252630",
+          overlay: "rgba(0, 0, 0, 0.5)",
+          input: "#252630",
+        },
+        foreground: {
+          primary: "#e4e4e7",
+          secondary: "#8b8d98",
+          muted: "#8b8d98",
+          disabled: "#52525b",
+          onAccent: "#ffffff",
+        },
+        border: {
+          default: "#2e3040",
+          strong: "#3f3f46",
+          subtle: "rgba(255, 255, 255, 0.06)",
+        },
+        interactive: {
+          hover: "rgba(255, 255, 255, 0.05)",
+          active: "rgba(129, 140, 248, 0.18)",
+          selected: "rgba(129, 140, 248, 0.12)",
+          focus: "#818cf8",
+        },
+      },
     },
     annotations: {
       annotationAuthor: "Sophosia",
@@ -221,6 +290,7 @@ function focusAnnotationIfNeeded(
 async function onViewerReady(registry: PluginRegistry) {
   viewerRegistry.value = registry;
   cleanupViewerSubscriptions();
+  injectCompactToolbarStyles();
 
   const annotationCapability = getCapability<AnnotationCapabilityLike>(
     registry,

--- a/src/components/settings/SettingsMenu.vue
+++ b/src/components/settings/SettingsMenu.vue
@@ -9,7 +9,7 @@
           :class="{ active: activeTab === tab.id }"
           @click="activeTab = tab.id"
         >
-          <component :is="tab.icon" width="12" height="12" />
+          <component :is="tab.icon" width="14" height="14" />
           <span>{{ $t(tab.label) }}</span>
         </button>
       </div>
@@ -73,7 +73,7 @@ const activeTab = ref("general");
   background: transparent;
   color: var(--q-text-muted);
   font-family: inherit;
-  font-size: 0.6875rem;
+  font-size: 0.875rem;
   font-weight: 500;
   line-height: 1;
   white-space: nowrap;

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -94,9 +94,9 @@ body {
 :root {
   --sidebar-width: 270px;
   --traffic-light-height: 0px;
-  --tab-bar-height: 34px;
-  --sub-tab-height: 34px;
-  --header-total-height: 68px; // tab-bar + sub-tab
+  --tab-bar-height: 40px;
+  --sub-tab-height: 40px;
+  --header-total-height: 80px; // tab-bar + sub-tab
 }
 
 body[data-platform="Darwin"] {

--- a/src/layouts/UnifiedSidebar.vue
+++ b/src/layouts/UnifiedSidebar.vue
@@ -202,7 +202,7 @@ defineEmits(["openPage"]);
 .sidebar-bottom-btn {
   border-radius: 6px;
   color: var(--q-text-muted);
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   transition: color 0.15s ease, background-color 0.15s ease;
 
   &:hover {


### PR DESCRIPTION
## Summary

Scaled up tab bars and unified typography for better readability. Customized the EmbedPDF PDF viewer toolbar to match the app's visual hierarchy and dark theme.

- Tab heights increased from 34px to 40px (matching EmbedPDF toolbar)
- All tab/sidebar fonts unified to 0.875rem (14px) for visual consistency
- EmbedPDF toolbar height reduced to 40px with proportionally-scaled 28px buttons
- PDF viewer always uses dark mode with app's indigo accent and dark color palette
- Removed redundant PDF toolbar items (document menu, sidebar toggle, page settings)

## Testing

- Verify tab bar and PDF toolbar are visually aligned (40px height)
- Check font sizes are consistent across tabs and sidebar
- Confirm PDF viewer displays in dark mode with correct colors
- Test zoom, pan, annotation tools remain functional with compact toolbar

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>